### PR TITLE
Change "master" to "main" in maintenance page

### DIFF
--- a/_pages/maintenance.html
+++ b/_pages/maintenance.html
@@ -26,7 +26,7 @@ description:
         </ul>
         <hr class="divider" />
         <h3>New Features</h3>
-        <p>Only added to the master branch and will not be made available in patch releases.</p>
+        <p>Only added to the main branch and will not be made available in patch releases.</p>
         <hr class="divider" />
         <h3>Bug Fixes</h3>
         <p>Only the latest release series will receive bug fixes. When enough bugs are fixed and its deemed worthy to release a new gem, this is the branch it happens from.</p>


### PR DESCRIPTION
Rails's main branch name is "main" now.