### PR TITLE
Update latest version to 7.0.1

### DIFF
--- a/_data/version.yml
+++ b/_data/version.yml
@@ -1,3 +1,3 @@
-label: Rails 7.0.0
-date: December 15, 2021
-url: /2021/12/15/Rails-7-fulfilling-a-vision
+label: Rails 7.0.1
+date: January 6, 2022
+url: /2022/1/6/Rails-7-0-1-has-been-released


### PR DESCRIPTION
Follow up to https://github.com/rails/website/commit/9e2c874.

This PR updates the latest Rails version announcement link to 7.0.1.
https://rubyonrails.org/2022/1/6/Rails-7-0-1-has-been-released