### PR TITLE
Update latest version to 7.0.2.2

### DIFF
--- a/_data/version.yml
+++ b/_data/version.yml
@@ -1,3 +1,3 @@
-label: Rails 7.0.2
-date: February 8, 2022
-url: /2022/2/8/Rails-7-0-2-has-been-released
+label: Rails 7.0.2.2
+date: February 11, 2022
+url: /2022/2/11/Rails-7-0-2-2-6-1-4-6-6-0-4-6-and-5-2-6-2-have-been-released


### PR DESCRIPTION
Follow up of https://github.com/rails/website/commit/e19b811.

This PR updates the latest Rails version announcement link to 7.0.2.2.
https://rubyonrails.org/2022/2/11/Rails-7-0-2-2-6-1-4-6-6-0-4-6-and-5-2-6-2-have-been-released