### PR TITLE
add Andrew White to the alumni

### DIFF
--- a/_data/community.yml
+++ b/_data/community.yml
@@ -117,3 +117,4 @@ alumni:
   - name: Scott Barron
   - name: Tobias Lütke
   - name: Rick Olson
+  - name: Andrew White


### PR DESCRIPTION
@pixeltrix I am sad to see you leaving, but I think you should be included in the Alumni. At least from my side this one is true for you: `We’d like to extend a special thanks to the following Rails Core team members`