### PR TITLE
Update latest version to 7.0.2.4

### DIFF
--- a/_data/version.yml
+++ b/_data/version.yml
@@ -1,3 +1,3 @@
-label: Rails 7.0.2.3
-date: March 8, 2022
-url: /2022/3/8/Rails-7-0-2-3-6-1-4-7-6-0-4-7-and-5-2-6-3-have-been-released
+label: Rails 7.0.2.4
+date: April 26, 2022
+url: /2022/4/26/Rails-7-0-2-4-6-1-5-1-6-0-4-8-and-5-2-7-1-have-been-released


### PR DESCRIPTION
Follow up https://github.com/rails/rails/commit/649516c

This PR updates the latest Rails version announcement link to 7.0.2.4.
https://rubyonrails.org/2022/4/26/Rails-7-0-2-4-6-1-5-1-6-0-4-8-and-5-2-7-1-have-been-released