### PR TITLE
Properly syntax-highlight ERB

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,7 +239,7 @@ end
       <div class="example__block example__block--align-left">
         <div class="example__code common-code">
           <h6>app/views/articles/show.html.erb</h6>
-{% highlight ruby %}
+{% highlight erb %}
 <h1><%= @article.title %></h1>
 
 <%= image_tag @article.cover_image.url %>


### PR DESCRIPTION
Also uses parenthesis around arguments to match rest of sample code.

There's the difference:

From:
<img width="674" alt="Screenshot 2022-06-12 at 17 32 20" src="https://user-images.githubusercontent.com/100293177/173240718-5d9a3a85-0d21-4eb0-9671-2c04075164e9.png">

To:
<img width="675" alt="Screenshot 2022-06-12 at 17 32 25" src="https://user-images.githubusercontent.com/100293177/173240721-1d56b07b-61d3-480d-bdca-005a0b411710.png">
