### PR TITLE
Update latest version to 7.0.3.1

### DIFF
--- a/_data/version.yml
+++ b/_data/version.yml
@@ -1,3 +1,3 @@
-label: Rails 7.0.3
-date: May 9, 2022
-url: /2022/5/9/Rails-7-0-3-6-1-6-6-0-5-and-5-2-8-have-been-released
+label: Rails 7.0.3.1
+date: July 12, 2022
+url: /2022/7/12/Rails-Versions-7-0-3-1-6-1-6-1-6-0-5-1-and-5-2-8-1-have-been-released


### PR DESCRIPTION
Follow up of https://github.com/rails/website/commit/3760387

This PR updates the latest Rails version announcement link to 7.0.3.1.
https://rubyonrails.org/2022/7/12/Rails-Versions-7-0-3-1-6-1-6-1-6-0-5-1-and-5-2-8-1-have-been-released