### PR TITLE
Blog posts: Don't strip newlines so that spacing between lines is rendered

### DIFF
--- a/_includes/post.html
+++ b/_includes/post.html
@@ -3,6 +3,6 @@
 
   <dl>
     <dt><a href="{{ post.url }}">{{ post.title | strip_html }}</a></dt>
-    <dd>{{ post.content | strip_html | strip_newlines | truncatewords: 30 }}</dd>
+    <dd>{{ post.content | strip_html | truncatewords: 30 }}</dd>
   </dl>
 </div>


### PR DESCRIPTION
Hi! First of all, I wanted to mention that I love the "This week in Rails" posts on the Rails blog, it's really nice to see what's coming down the pipeline on a regular basis.

When I was browsing the blog today, I noticed this oddity on the Rails blog for the "This week in Rails" posts. It seemed like the whitespaces between lines were getting removed, leading to words being smushed together like this:

![image](https://user-images.githubusercontent.com/47774/202119140-b09a330c-5a02-4b38-a45b-8f18bde0f48d.png)

>     Hi there,This is Greg, bringing you the latest changes in Rails.Fix Enumerable#many? to handle all block parametersBefore this fix, Enumerable#many? didn’t forward the block parameters to the block, so if...

I took a look at the template, and noticed that we're stripping newlines from the blog post before rendering its summary. But since HTML basically [collapses whitespace into a single space](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Whitespace), this doesn't actually result in newlines being rendered on the blog homepage. So it seemed to me like the `strip_newlines` call was unnecessary, and removing it would fix the whitespace issue. Here is the same post from my local machine with these changes:

![image](https://user-images.githubusercontent.com/47774/202119600-d353e94e-15bf-45f6-aa12-8948e72a9a59.png)

>     Hi there, This is Greg, bringing you the latest changes in Rails. Fix Enumerable#many? to handle all block parameters Before this fix, Enumerable#many? didn’t forward the block parameters to the...

(On a related note, this makes me think that it would be great if the links at the beginning of the posts ended in a period so that there was a clearer distinction between the title of the change and the body. e.g. "Fix Enumerable#many? to handle all block parameters Before this fix", there's no distinction between the title of the change (the link text) and the body, so we just suddenly come across a "Before" capitalized.) Even on the main blog post page I think it's clearer with a period, although at least with the link styles it is clearer where the "title" ends. But that would require changing the post content which seems more annoying to do 🤷🏾.)

![image](https://user-images.githubusercontent.com/47774/202120550-9737fc87-984d-4aae-83ce-9c90cf34dfd2.png)

Sorry for the random contribution, but I just want the Rails website to be as polished as it can be. Thank you for your time and for supporting Rails!