### PR TITLE
Fix typos

### DIFF
--- a/_pages/community.html
+++ b/_pages/community.html
@@ -26,7 +26,7 @@ redirect_from:
       </div>
 
       <div class="core__content common-content common-content--size-large">
-        <p><strong>The direction of the framework is stewarded by the Rails Core.</strong> This group of long-term contributors manage releases, evaluate pull-requests, handle conduct complaints, and does a lot of the groundwork on major new features.</p>
+        <p><strong>The direction of the framework is stewarded by the Rails Core.</strong> This group of long-term contributors manages releases, evaluates pull-requests, handles conduct complaints, and does a lot of the groundwork on major new features.</p>
       </div>
 
       <div class="core__members">
@@ -71,7 +71,7 @@ redirect_from:
 
       <div class="core__content common-content common-content--size-large">
         <p>
-          <strong>The Issues team assists with issues triage, pull request reviews and documentation improvements.</strong>
+          <strong>The Issues team assists with issues triage, pull request reviews, and documentation improvements.</strong>
           They are often the first point of interaction of users with the Rails team:
 
           {% for member in site.data.community.issues %}

--- a/_pages/security.html
+++ b/_pages/security.html
@@ -35,7 +35,7 @@ redirect_from:
           <li>Send an email to the security reports list <a href="mailto:security@rubyonrails.org">security@rubyonrails.org</a>.</li>
           <li>Contact the current security coordinator <a href="mailto:rafaelmfranca@gmail.com">Rafael França</a> directly.</li>
           <li>Contact the backup contact <a href="mailto:jeremy@basecamp.com">Jeremy Daer</a> directly.</li>
-          <li>Email the <a href="https://discuss.rubyonrails.org/c/rubyonrails-core">Rails core list</a> or ask in  <a href="https://discord.gg/d8N68BCw49">the Rails Discord server</a>.</li>
+          <li>Email the <a href="https://discuss.rubyonrails.org/c/rubyonrails-core">Rails core list</a> or ask in <a href="https://discord.gg/d8N68BCw49">the Rails Discord server</a>.</li>
         </ul>
         <p>Please note, the Rails core list and Rails Discord server are public areas. When escalating to that address please do not discuss your issue, simply say that you’re trying to get a hold of someone from the security team.</p>
         <hr class="divider" />
@@ -48,7 +48,7 @@ redirect_from:
         <p>This process can take some time, especially when coordination is required with maintainers of other projects. Every effort will be made to handle the bug in as timely a manner as possible, however it’s important that we follow the release process above to ensure that the disclosure is handled in a consistent manner.</p>
         <hr class="divider" />
         <h3>Receiving Disclosures</h3>
-        <p>The best way to receive all the security announcements is to subscribe to the <a href="https://discuss.rubyonrails.org/c/security-announcements/9">Rails Security Announements section of the forum</a>. This section is very low traffic, and it receives the public notifications the moment the embargo is lifted.</p>
+        <p>The best way to receive all the security announcements is to subscribe to the <a href="https://discuss.rubyonrails.org/c/security-announcements/9">Rails Security Announcements section of the forum</a>. This section is very low traffic, and it receives the public notifications the moment the embargo is lifted.</p>
         <p>No one outside the security team or the initial reporter will be notified prior to the lifting of the embargo. We regret that we cannot make exceptions to this policy for high traffic or important sites, as any disclosure beyond the minimum required to coordinate a fix could cause an early leak of the vulnerability.</p>
         <p>If you have any suggestions to improve this policy, please send an email to <a href="mailto:security@rubyonrails.org">security@rubyonrails.org</a>.</p>
       </div>


### PR DESCRIPTION
* "This group of long-term contributors"
  => singular verb subject
* "issues triage, pull request reviews and documentation improvements"
  => Oxford comma
* "Security Announements"
  => "Security Announcements"