### PR TITLE
Update and Fixed relative path traversal vulnerability allows loading of arbitrary files 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,7 +269,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.9)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext


### PR DESCRIPTION
### Description The Summary
With the Ruby data source (the tzinfo-data gem for tzinfo version 1.0.0 and later and built-in to earlier versions), time zones are defined in Ruby files. There is one file per time zone. Time zone files are loaded with `require` on demand. In the affected versions, `TZInfo::Timezone.get` fails to validate time zone identifiers correctly, allowing a new line character within the identifier. With Ruby version 1.9.3 and later, `TZInfo::Timezone.get` can be made to load unintended files with `require`, executing them within the Ruby process.


vulnerable with version 1.2.9, you can run the following to load a file with path /tmp/payload.rb:
```rb
TZInfo::Timezone.get("foo\n/../../../../../../../../../../../../../../../../tmp/payload")
```
The exact number of parent directory traversals needed will vary depending on the location of the tzinfo-data gem. TZInfo versions 1.2.6 to 1.2.9 can be made to load files from outside of the Ruby load path. Versions up to and including 1.2.5 can only be made to load files from directories within the load path. This could be exploited in, for example, a Ruby on Rails application using tzinfo version 1.2.9, that allows file uploads and has a time zone selector that accepts arbitrary time zone identifiers. The CVSS score and severity have been set on this basis.

### Workarounds
As a workaround, the time zone identifier can be validated before passing to `TZInfo::Timezone.get` by ensuring it matches the regular expression `\A[A-Za-z0-9+\-_]+(?:\/[A-Za-z0-9+\-_]+)*\z`.


[CWE-22](https://cwe.mitre.org/data/definitions/22.html)
[CWE-23](https://cwe.mitre.org/data/definitions/23.html)
`CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H`



**Affected:**
 * 0.3.60 and earlier.
 * 1.0.0 to 1.2.9 when used with the Ruby data source (tzinfo-data).
