### PR TITLE
Add focus styles to links

### DIFF
--- a/_sass/common/_button.scss
+++ b/_sass/common/_button.scss
@@ -30,7 +30,8 @@
     vertical-align: middle;
   }
 
-  &:hover {
+  &:hover,
+  &:focus {
     background: $color-black;
   }
 
@@ -51,7 +52,8 @@
       padding: 0 !important;
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
       background: $color-grey-3;
       color: $color-red;
     }
@@ -79,7 +81,8 @@
       text-decoration-thickness: 2px;
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
       background: none;
       color: $color-red;
     }
@@ -99,8 +102,13 @@
       width: 9px;
     }
 
-    &:hover span:after {
-      filter: $filter-red;
+    &:hover,
+    &:focus {
+
+      span:after {
+        filter: $filter-red;
+      }
+
     }
 
   }
@@ -125,7 +133,8 @@
     background: $color-black;
     color: $color-white;
 
-    &:hover {
+    &:hover,
+    &:focus {
       background: $color-red;
     }
 
@@ -136,7 +145,8 @@
     background: $color-red;
     color: $color-white;
 
-    &:hover {
+    &:hover,
+    &:focus {
       background: $color-black;
     }
 

--- a/_sass/common/_content.scss
+++ b/_sass/common/_content.scss
@@ -193,7 +193,8 @@
       color: inherit;
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
       color: $color-black;
     }
 
@@ -276,7 +277,8 @@
 
         color: $color-black;
 
-        &:hover {
+        &:hover,
+        &:focus {
           color: $color-red;
         }
 

--- a/_sass/common/_headline.scss
+++ b/_sass/common/_headline.scss
@@ -63,7 +63,8 @@
     text-decoration: underline;
     text-decoration-thickness: 2px;
 
-    &:hover {
+    &:hover,
+    &:focus {
       color: $color-red;
     }
 

--- a/_sass/modules/_blog.scss
+++ b/_sass/modules/_blog.scss
@@ -45,7 +45,8 @@
           color: $color-red;
           text-decoration: underline;
 
-          &:hover {
+          &:hover,
+          &:focus {
             color: $color-black;
           }
 
@@ -65,7 +66,8 @@
           color: $color-red;
           text-decoration: underline;
 
-          &:hover {
+          &:hover,
+          &:focus {
             color: $color-black;
           }
 

--- a/_sass/modules/_cards.scss
+++ b/_sass/modules/_cards.scss
@@ -28,7 +28,8 @@
 
       display: block;
 
-      &:hover {
+      &:hover,
+      &:focus {
 
         .card__label h6 {
           background: $color-red;

--- a/_sass/modules/_core.scss
+++ b/_sass/modules/_core.scss
@@ -102,7 +102,8 @@
           width: 82px;
         }
 
-        &:hover {
+        &:hover,
+        &:focus {
           border-color: $color-red;
         }
 
@@ -128,7 +129,8 @@
           text-decoration: underline;
           text-decoration-thickness: 2px;
 
-          &:hover {
+          &:hover,
+          &:focus {
             color: $color-black;
           }
 
@@ -171,7 +173,8 @@
           padding: 4px 12px;
           transition: background $transition, color $transition;
 
-          &:hover {
+          &:hover,
+          &:focus {
             background: $color-red;
             color: $color-white;
           }

--- a/_sass/modules/_footer.scss
+++ b/_sass/modules/_footer.scss
@@ -32,8 +32,13 @@
         width: 90px;
       }
 
-      &:hover:after {
-        filter: $filter-black;
+      &:hover,
+      &:focus {
+
+        &:after {
+          filter: $filter-black;
+        }
+
       }
 
     }
@@ -55,7 +60,8 @@
         color: $color-grey-5;
         display: inline-block;
 
-        &:hover {
+        &:hover,
+        &:focus {
           color: $color-black;
           text-decoration: underline;
         }

--- a/_sass/modules/_heading.scss
+++ b/_sass/modules/_heading.scss
@@ -83,9 +83,13 @@
         transition: background $transition, color $transition;
       }
 
-      &:hover span {
-        background: $color-grey-1;
-        color: $color-red;
+      &:hover,
+      &:focus {
+        span {
+          background: $color-grey-1;
+          color: $color-red;
+        }
+
       }
 
     }

--- a/_sass/modules/_icon.scss
+++ b/_sass/modules/_icon.scss
@@ -17,8 +17,13 @@
     width: 15px;
   }
 
-  &:hover:after {
-    filter: $filter-black;
+  &:hover,
+  &:focus {
+
+    &:after {
+      filter: $filter-black;
+    }
+
   }
 
 

--- a/_sass/modules/_language.scss
+++ b/_sass/modules/_language.scss
@@ -73,7 +73,8 @@
       width: 7px;
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
       background: $color-grey-2;
     }
 
@@ -116,9 +117,14 @@
             transition: background $transition, color $transition;
           }
 
-          &:hover span {
-            background: $color-grey-1;
-            color: $color-black;
+          &:hover,
+          &:focus {
+
+            span {
+              background: $color-grey-1;
+              color: $color-black;
+            }
+
           }
 
         }

--- a/_sass/modules/_nav.scss
+++ b/_sass/modules/_nav.scss
@@ -33,7 +33,8 @@
       width: 67px;
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
       background: $color-black;
     }
 
@@ -81,9 +82,12 @@
             transition: background $transition, color $transition;
           }
 
-          &:hover span {
-            background: $color-grey-1;
-            color: $color-red;
+          &:hover,
+          &:focus {
+            span {
+              background: $color-grey-1;
+              color: $color-red;
+            }
           }
 
         }
@@ -191,11 +195,15 @@
 
     }
 
-    &:hover span {
+    &:hover,
+    &:focus {
+      span {
 
-      &:before,
-      &:after {
-        background: $color-red;
+        &:before,
+        &:after {
+          background: $color-red;
+        }
+
       }
 
     }

--- a/_sass/modules/_notification.scss
+++ b/_sass/modules/_notification.scss
@@ -23,7 +23,8 @@
       font-weight: 600;
       text-decoration: underline;
 
-      &:hover {
+      &:hover,
+      &:focus {
         color: rgba($color-white, 0.9);
       }
 

--- a/_sass/modules/_post.scss
+++ b/_sass/modules/_post.scss
@@ -74,7 +74,8 @@
           color: $color-red;
           text-decoration: underline;
 
-          &:hover {
+          &:hover,
+          &:focus {
             color: $color-black;
           }
 

--- a/_sass/modules/_trusted.scss
+++ b/_sass/modules/_trusted.scss
@@ -39,7 +39,8 @@
         width: auto;
       }
 
-      &:hover {
+      &:hover,
+      &:focus {
         background: $color-white;
         box-shadow: 0 0 0 3px $color-red;
         transform: translateY(-3px);


### PR DESCRIPTION
Currently there are no `:focus` states on any of the links, so if you're tabbing through the site you have _no idea_ where you are.

I've tried to follow the existing CSS patterns as best I can.

Ultimately it would be good to have an outline to give a clearer indication of what's currently being focussed, but I'm very much not a designer, so I'll leave that up to someone with skills in that area. For example here "contributed code to Rails" is focussed, but it's not overly clear:
<img width="1098" alt="CleanShot 2023-03-16 at 17 32 57@2x" src="https://user-images.githubusercontent.com/1290100/225704835-3bc0f84a-ad24-415e-a8cb-f954d7b8aee5.png">
