### PR TITLE
add a landing page for the newsletter and redirect it to the Hey page

### DIFF
--- a/_pages/newsletter.html
+++ b/_pages/newsletter.html
@@ -1,0 +1,23 @@
+---
+title: This Week in Rails Newsletter
+description: Your weekly inside scoop of interesting commits, pull requests and more from Rails.
+permalink: /newsletter
+redirect_to:
+  - https://world.hey.com/this.week.in.rails
+---
+
+<div class="heading common-padding--bottom common-padding--top-small">
+  <div class="container">
+    <div class="heading__body">
+      <div class="heading__headline common-headline">
+        <h1>This Week in Rails Newsletter</h1>
+      </div>
+      <div class="heading__content heading__content--has-headline common-content common-content--size-large">
+        <h5>Your weekly inside scoop of interesting commits, pull requests and more from Rails.</strong></h5>
+        <p>
+          <a href="https://world.hey.com/this.week.in.rails">Subscribe</a> to get these updates mailed to you.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
To make it easier to share a URL for the newsletter, David agreed to add a redirection to the Hey page from /newsletter. 
I added a simple page in case the redirect doesn't happen for some reason:

![image](https://user-images.githubusercontent.com/752058/228833363-687e6810-696a-4564-8757-ad22a738b2a3.png)
