### PR TITLE
Update latest version to 7.0.5

### DIFF
--- a/_data/version.yml
+++ b/_data/version.yml
@@ -1,3 +1,3 @@
-label: Rails 7.0.4.3
-date: March 13, 2023
-url: /2023/3/13/Rails-7-0-4-3-and-6-1-7-3-have-been-released
+label: Rails 7.0.5
+date: May 24, 2023
+url: /2023/5/24/Rails-7-0-5-has-been-released


### PR DESCRIPTION
Follow up of https://github.com/rails/website/commit/54b8a4c

This PR updates the latest Rails version announcement link to 7.0.5.
https://rubyonrails.org/2023/5/24/Rails-7-0-5-has-been-released