### PR TITLE
fix logo jumping on scroll and make responsive to landscape mode

### DIFF
--- a/_sass/modules/_world.scss
+++ b/_sass/modules/_world.scss
@@ -13,7 +13,8 @@
       width: min(50vw, 300px);
       cursor: pointer;
       position: fixed;
-      top: 50%;
+      top: 50vh;
+      top: 50svh;
       left: 50%;
       transform: translateY(-50%) translateX(-50%);
       z-index: 1;
@@ -25,6 +26,12 @@
         max-height: 30vh;
       }
     }
+
+    @media (max-height: 500px) {
+      .world__ul {
+        padding-bottom: 0;
+      }
+    }
   }
 
   &__button {
@@ -33,8 +40,7 @@
 
   &__bottom {
     position: relative;
-    height: 100vh; // for browsers that don't support svh
-    height: 100svh;
+    height: 100vh;
     display: flex;
     justify-content: center;
     align-items: end;


### PR DESCRIPTION
This PR fixes the logo jump on scrolling and makes the conference information section responsive on mobile landscape modes.

Before:
https://github.com/radioactivetoyhq/rubyonrails-website/assets/99415923/dfc6a4ff-3d56-4d12-983e-a5daf4b8f87e


After:
https://github.com/radioactivetoyhq/rubyonrails-website/assets/99415923/6b9a6d06-48ee-445c-b64b-56526d08a460

