### PR TITLE
Fix Rails World carousel layout on Safari 15

### DIFF
--- a/_sass/world/modules/_speaker_card.scss
+++ b/_sass/world/modules/_speaker_card.scss
@@ -13,11 +13,14 @@ speaker-card {
   }
 
   img {
+    --size: 8em;
     border-radius: 50%;
     margin: var(--space-small);
     padding-bottom: var(--space-x-small);
-    aspect-ratio: 1/1;
     object-fit: cover;
+    height: var(--size);
+    width: var(--size);
+    align-self: center;
   }
 
   h3 {

--- a/_sass/world/modules/_speaker_carousel.scss
+++ b/_sass/world/modules/_speaker_carousel.scss
@@ -28,7 +28,6 @@ carousel-component {
     display: flex;
     overflow: scroll;
     gap: var(--space-medium);
-    align-items: center;
     padding-bottom: var(--space-medium);
     scrollbar-width: none;
     scroll-snap-type: x mandatory;


### PR DESCRIPTION
Bug report on Safari 15:

![Screenshot_2023-06-23_at_16 59 43](https://github.com/rails/website/assets/4924039/02064a16-e924-4860-b525-8c66f7b1efc2)

This PR fixes the issue by defining a size for the image.