### PR TITLE
Remove purple bubble and fix FAQ font size

### DIFF
--- a/_sass/world/modules/_faq.scss
+++ b/_sass/world/modules/_faq.scss
@@ -104,6 +104,11 @@
       font-variation-settings: var(--font-weight-400);
       margin-left: var(--space-large);
       margin-top: var(--space-small);
+
+      /* Extra small devices (phones, 600px and down) */
+      @media only screen and (max-width: 600px) {
+        font-size: var(--type-small);
+      }
     }
   }
 }

--- a/_sass/world/modules/_hero.scss
+++ b/_sass/world/modules/_hero.scss
@@ -25,32 +25,6 @@
       position: relative;
       margin-bottom: var(--space-small);
     }
-
-    &__bubble {
-      display: flex;
-      align-items: center;
-      background-color: var(--purple-medium);
-      width: 120px;
-      min-height: 4em;
-      padding: 16px;
-      font-variation-settings: var(---font-weight-600);
-      border-radius: 50%;
-      position: absolute;
-      line-height: 1.2;
-      top: 0;
-      right: 0;
-      transform: translate(85%, -50%);
-      z-index: 1;
-
-      span {
-        margin-top: 5px;
-      }
-
-      /* Tablet devices (900px and down) */
-      @media only screen and (max-width: 900px) {
-        display: none;
-      }
-    }
   }
 
   &__location {

--- a/world/index.html
+++ b/world/index.html
@@ -12,10 +12,6 @@ permalink: /world
     <div class="hero__content">
 
       <h1>Shaping the future of Ruby on Rails</h1>
-      <p class="hero__content__bubble">
-        <span>20 years of Ruby on Rails</span>
-      </p>
-
       <p>October 5 & 6</p>
       <p class="hero__location">
         {% include world/icons/pin.html %}


### PR DESCRIPTION
This PR removes the purple bubble in the hero section and reduces the font size of lists in FAQ answers to match the `<p>` elements on mobile screen sizes