### PR TITLE
Remove tito to address XSS attack

### DIFF
--- a/_includes/world/head.html
+++ b/_includes/world/head.html
@@ -57,7 +57,6 @@
   </script>
   <script defer data-domain="rubyonrails.org" src="https://plausible.io/js/script.js"></script>
 
-  <script src="https://js.tito.io/v2" async></script>
   <script src="/assets/world/scripts/back_to_top.js" defer></script>
   <script src="/assets/world/scripts/carousel.js" defer></script>
 

--- a/_includes/world/header.html
+++ b/_includes/world/header.html
@@ -11,7 +11,7 @@
       {% endif %}
 
       <li><a href="/world/faq" class="nav__link">FAQs</a></li>
-      <li><tito-button event="rails-world/rails-world-2023">Sold out</tito-button></li>
+      <li><button class="tito" disabled>Sold out</button></li>
     </ul>
   </nav>
 </header>

--- a/_sass/world/common/_button.scss
+++ b/_sass/world/common/_button.scss
@@ -4,6 +4,7 @@ button {
   &[disabled], &:disabled {
     opacity: 0.5;
     cursor: auto;
+    pointer-events: none;
   }
 }
 
@@ -25,7 +26,7 @@ button {
   }
 }
 
-.tito-widget-button {
+button.tito {
   display: inline-block;
   font-family: inherit;
   font-size: var(--type-small);
@@ -50,7 +51,7 @@ a:hover:not(.button) {
   transition: transform 0.05s linear;
 }
 
-.button:hover, .tito-widget-button:hover {
+.button:hover, button.tito:hover {
   background: var(--orange-red);
   color: var(--white);
 }

--- a/_sass/world/modules/_faq.scss
+++ b/_sass/world/modules/_faq.scss
@@ -104,6 +104,11 @@
       font-variation-settings: var(--font-weight-400);
       margin-left: var(--space-large);
       margin-top: var(--space-small);
+
+      /* Extra small devices (phones, 600px and down) */
+      @media only screen and (max-width: 600px) {
+        font-size: var(--type-small);
+      }
     }
   }
 }

--- a/_sass/world/modules/_header.scss
+++ b/_sass/world/modules/_header.scss
@@ -32,7 +32,7 @@
     font-size: var(--type-medium);
   }
 
-  .tito-widget-button {
+  button.tito {
     padding: var(--space-x-small) var(--space-medium);
 
     @media only screen and (max-width: 1100px) {

--- a/_sass/world/modules/_hero.scss
+++ b/_sass/world/modules/_hero.scss
@@ -25,32 +25,6 @@
       position: relative;
       margin-bottom: var(--space-small);
     }
-
-    &__bubble {
-      display: flex;
-      align-items: center;
-      background-color: var(--purple-medium);
-      width: 120px;
-      min-height: 4em;
-      padding: 16px;
-      font-variation-settings: var(---font-weight-600);
-      border-radius: 50%;
-      position: absolute;
-      line-height: 1.2;
-      top: 0;
-      right: 0;
-      transform: translate(85%, -50%);
-      z-index: 1;
-
-      span {
-        margin-top: 5px;
-      }
-
-      /* Tablet devices (900px and down) */
-      @media only screen and (max-width: 900px) {
-        display: none;
-      }
-    }
   }
 
   &__location {

--- a/world/index.html
+++ b/world/index.html
@@ -12,10 +12,6 @@ permalink: /world
     <div class="hero__content">
 
       <h1>Shaping the future of Ruby on Rails</h1>
-      <p class="hero__content__bubble">
-        <span>20 years of Ruby on Rails</span>
-      </p>
-
       <p>October 5 & 6</p>
       <p class="hero__location">
         {% include world/icons/pin.html %}

--- a/world/index.html
+++ b/world/index.html
@@ -21,7 +21,7 @@ permalink: /world
       </p>
 
       <br>
-      <tito-button event="rails-world/rails-world-2023">Sold out</tito-button>
+      <button class="tito" disabled>Sold out</button>
     </div>
   </section>
 


### PR DESCRIPTION
The tito embed was causing an XSS vulnerability. Since tickets are sold out we can remove tito from the site. This PR also address a couple of other small UI bugs.