### PR TITLE
Update latest version to 7.0.6

### DIFF
--- a/_data/version.yml
+++ b/_data/version.yml
@@ -1,3 +1,3 @@
-label: Rails 7.0.5.1
-date: June 26, 2023
-url: /2023/6/26/Rails-Versions-7-0-5-1-6-1-7-4-have-been-released
+label: Rails 7.0.6
+date: June 29, 2023
+url: /2023/6/29/Rails-7-0-6-has-been-released


### PR DESCRIPTION
Follow up of https://github.com/rails/website/commit/72e043c.

This PR updates the latest Rails version announcement link to 7.0.6:
https://rubyonrails.org/2023/6/29/Rails-7-0-6-has-been-released