### PR TITLE
Update latest version to 7.0.7

### DIFF
--- a/_data/version.yml
+++ b/_data/version.yml
@@ -1,3 +1,3 @@
-label: Rails 7.0.6
-date: June 29, 2023
-url: /2023/6/29/Rails-7-0-6-has-been-released
+label: Rails 7.0.7
+date: August 10, 2023
+url: /2023/8/10/Rails-7-0-7-has-been-released


### PR DESCRIPTION
Follow up of https://github.com/rails/website/commit/8ffbef0.

This PR updates the latest Rails version announcement link to 7.0.7. https://rubyonrails.org/2023/8/10/Rails-7-0-7-has-been-released