### PR TITLE
Update Lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check spelling all files with codespell
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
This PR updates the Lint workflow to use the latest version (v4) of the checkout action