### PR TITLE
Update conduct history to link to new repository

### DIFF
--- a/_pages/conduct.html
+++ b/_pages/conduct.html
@@ -55,7 +55,7 @@ redirect_from:
         <hr class="divider" />
         <h3>Attribution</h3>
         <p>This Code of Conduct is adapted from the <a href="https://contributor-covenant.org">Contributor Covenant</a>, version 1.4, available at <a href="https://contributor-covenant.org/version/1/4">https://contributor-covenant.org/version/1/4</a>.</p>
-        <p>For a history of updates and revisions to this policy, see the <a href="https://github.com/rails/homepage/commits/master/conduct.html">page history</a>.</p>
+        <p>For a history of updates and revisions to this policy, see the <a href="https://github.com/rails/website/commits/main/_pages/conduct.html">page history</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The current one links to the previous repository. Being linked to the archived repository is unexpected.

Unfortunatly history was not preserved, don't know what to do about that.