### PR TITLE
Adjust mobile nav height to not cut off "Jobs"

### DIFF
--- a/_sass/modules/_nav.scss
+++ b/_sass/modules/_nav.scss
@@ -129,7 +129,7 @@
 
         div {
           box-shadow: 0 15px 70px 5px rgba($color-black, 0.15), 0 1px 1px rgba($color-black, 0.04);
-          height: 338px;
+          height: 385px;
         }
 
       }


### PR DESCRIPTION
Heya! Love the official job board. Unfortunately, it looks like the mobile navbar has a fixed height, so currently the `Job` entry in the mobile menu is being cut off.
<img width="580" alt="Screenshot 2023-11-27 at 11 27 19 AM" src="https://github.com/rails/website/assets/20427632/28953aae-2835-4cb8-a07b-9e8d82476297">

This PR just extends that height a bit to prevent the list element from being cut off.