### PR TITLE
#217 Removing redirect from pages, produces infinite redirect in localhost

### DIFF
--- a/_pages/community.html
+++ b/_pages/community.html
@@ -2,8 +2,6 @@
 title: Community
 description:
 permalink: /community
-redirect_from:
-  - /community/
 ---
 
 <div class="heading common-padding--bottom common-padding--top-small">

--- a/_pages/conduct.html
+++ b/_pages/conduct.html
@@ -2,8 +2,6 @@
 title: Code of Conduct
 description:
 permalink: /conduct
-redirect_from:
-  - /conduct/
 ---
 
 <div class="heading common-padding--bottom common-padding--top-small">

--- a/_pages/maintenance.html
+++ b/_pages/maintenance.html
@@ -2,8 +2,6 @@
 title: Maintenance policy
 description:
 permalink: /maintenance
-redirect_from:
-  - /maintenance/
 ---
 
 <div class="heading common-padding--bottom common-padding--top-small">

--- a/_pages/privacy.html
+++ b/_pages/privacy.html
@@ -2,8 +2,6 @@
 title: Privacy
 description:
 permalink: /foundation/privacy
-redirect_from:
-  - /privacy/
 ---
 
 <div class="heading common-padding--bottom common-padding--top-small">

--- a/_pages/security.html
+++ b/_pages/security.html
@@ -2,8 +2,6 @@
 title: Security
 description:
 permalink: /security
-redirect_from:
-  - /security/
 ---
 
 <div class="heading common-padding--bottom common-padding--top-small">

--- a/_pages/trademarks.html
+++ b/_pages/trademarks.html
@@ -2,8 +2,6 @@
 title: Trademarks policy
 description:
 permalink: /trademarks
-redirect_from:
-  - /trademarks/
 ---
 
 <div class="heading common-padding--bottom-small common-padding--top">


### PR DESCRIPTION
# What changed?
 
The redirects headers were removed from some pages given they were creating an infinite redirect loop when working from localhost. 

The issue seems to be that the internal routing from the jekyll serve command get's confused because we have both a folder and an html file the same name as the route. It seems to be taking the folder route as priority but then inside the folder there is an index.html file that tries to redirect to the .html file.

It probably works on the server side because they are using nginx and the routing order is handled differently/correctly.

The only consequence of this change is that we would have the / at the end of the affected pages routes.

A few images to illustrate the issue:

![confusing_routing](https://github.com/rails/website/assets/1693000/27701dac-c797-454b-91d2-9431a40ffa78)

![confusing_routing2](https://github.com/rails/website/assets/1693000/60a2bb03-2abb-4896-a376-9c409a6b0372)


