### PR TITLE
Rails World 2024 - Polish updates

### DIFF
--- a/_includes/world/2024/announcements.html
+++ b/_includes/world/2024/announcements.html
@@ -2,7 +2,9 @@
 {% if announcements %}
   <div class="announcements">
     {% for announcement in announcements %}
-      <p>{{ announcement.content }}</p>
+      <div class="textContainer">
+        <p>{{ announcement.content }}</p>
+      </div>
     {% endfor %}
   </div>
 {% endif %}

--- a/_includes/world/2024/footer.html
+++ b/_includes/world/2024/footer.html
@@ -7,56 +7,35 @@
       <div class="textContainer">
         <p>
           This website was designed and created by
-          <a 
-            href="https://www.johnfarina.co/" 
-            aria-label="John Farina's web portfiolio" 
-            target="_blank" 
-            class="button main x-small my-button"
-          >
+          <a href="https://www.johnfarina.co/" aria-label="John Farina's web portfiolio" target="_blank"
+            class="button main x-small my-button">
             John Farina
-          </a>: a junior developer from the Rails community.
+          </a> - a junior developer from the Rails community.
         </p>
       </div>
       <div class="footerLegalContainer">
-        <a 
-          href="/world/2024/conduct" 
-          aria-label="Code of Conduct" 
-          target="_blank" 
-          class="link small footerLink"
-        >
+        <a href="/world/2024/conduct" aria-label="Code of Conduct" target="_blank" class="link small footerLink">
           Code of Conduct
         </a>
-        <a 
-          href="/foundation/privacy" 
-          aria-label="Privacy Policy" 
-          target="_blank" 
-          class="link small"
-        >
+        <a href="/foundation/privacy" aria-label="Privacy Policy" target="_blank" class="link small">
           Privacy Policy
         </a>
-        <a 
-          href="/world/2024/terms" 
-          aria-label="Terms and Conditions" 
-          target="_blank" 
-          class="link small"
-        >
+        <a href="/world/2024/terms" aria-label="Terms and Conditions" target="_blank" class="link small">
           Terms & Conditions
         </a>
       </div>
     </div>
 
     <div class="sideContainer right">
-      <div class="socialLinks">
-        <a href="https://twitter.com/rails" aria-label="Rails on Twitter" target="_blank">
-          {% include world/2023/icons/twitter.html %}
-        </a>
-        <a 
-          href="https://www.linkedin.com/company/ruby-on-rails-org/" 
-          aria-label="Rails on LinkedIn" 
-          target="_blank"
-        >
-          {% include world/2023/icons/linkedin.html %}
-        </a>
+      <div class="linksContainer">
+        <div class="socialLinks">
+          <a href="https://twitter.com/rails" aria-label="Rails on Twitter" target="_blank">
+            {% include world/2023/icons/twitter.html %}
+          </a>
+          <a href="https://www.linkedin.com/company/ruby-on-rails-org/" aria-label="Rails on LinkedIn" target="_blank">
+            {% include world/2023/icons/linkedin.html %}
+          </a>
+        </div>
       </div>
     </div>
   </div>

--- a/_includes/world/2024/head.html
+++ b/_includes/world/2024/head.html
@@ -79,4 +79,10 @@
   <link rel="stylesheet" href="https://use.typekit.net/lar2lzk.css">
   <link rel="stylesheet" href="/assets/css/world-2024.css" />
   <link rel="canonical" href="{{ url }}" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+  <link
+    href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap"
+    rel="stylesheet">
 </head>

--- a/_includes/world/2024/slideshow.html
+++ b/_includes/world/2024/slideshow.html
@@ -8,7 +8,6 @@
             alt="Evergreen Brick Works - picture of inside building hallway" class="slideImage">
     </div>
     <div class="slide">
-        <!-- lazy load these images -->
         <img loading="lazy" src="/assets/world/2024/images/locationSlideshow3.jpg"
             alt="Evergreen Brick Works - different angle of inside building" class="slideImage">
     </div>

--- a/_includes/world/2024/slideshow.html
+++ b/_includes/world/2024/slideshow.html
@@ -1,35 +1,27 @@
-<div class="slideshowContainer">
+<div aria-controls="carousel" class="slideshowContainer">
     <div class="slide">
-        <img 
-            src="/assets/world/2024/images/locationSlideshow1.jpg" 
-            alt="Evergreen Brick Works - picture of inside building" 
-            class="slideImage"
-        >
+        <img loading="lazy" src="/assets/world/2024/images/locationSlideshow1.jpg"
+            alt="Evergreen Brick Works - picture of inside building" class="slideImage">
     </div>
     <div class="slide">
-        <img 
-            src="/assets/world/2024/images/locationSlideshow2.jpg" 
-            alt="Evergreen Brick Works - picture of inside building hallway" 
-            class="slideImage"
-        >
+        <img loading="lazy" src="/assets/world/2024/images/locationSlideshow2.jpg"
+            alt="Evergreen Brick Works - picture of inside building hallway" class="slideImage">
     </div>
     <div class="slide">
-        <img 
-            src="/assets/world/2024/images/locationSlideshow3.jpg" 
-            alt="Evergreen Brick Works - different angle of inside building" 
-            class="slideImage"
-        >
+        <!-- lazy load these images -->
+        <img loading="lazy" src="/assets/world/2024/images/locationSlideshow3.jpg"
+            alt="Evergreen Brick Works - different angle of inside building" class="slideImage">
     </div>
 
-    <div class="dotsContainer">
+    <div aria-label="carousel buttons" class="dotsContainer">
         <!-- We generate the dots here -->
     </div>
 
-    <div class="buttonsContainer">
-        <button class="button slideShow left" onclick="backwardSlide()">
+    <div aria-label="carousel buttons" class="buttonsContainer">
+        <button aria-label="previous" class="button slideShow left" onclick="backwardSlide()">
             <img class="arrowSvg" src="/assets/world/2024/images/arrow.svg" alt="arrow">
         </button>
-        <button class="button slideShow" onclick="forwardSlide()">
+        <button aria-label="next" class="button slideShow" onclick="forwardSlide()">
             <img class="arrowSvg" src="/assets/world/2024/images/arrow.svg" alt="arrow">
         </button>
     </div>
@@ -47,6 +39,7 @@
             const dot = document.createElement("button");
             dot.classList.add("button")
             dot.classList.add("dot")
+            dot.ariaLabel = `Slide ${i + 1}`
 
             dot.onclick = () => {
                 currentSlideIndex = i + 1;

--- a/_sass/world/2024/base/_body.scss
+++ b/_sass/world/2024/base/_body.scss
@@ -14,7 +14,7 @@ h5 {
 
 p {
   font-family: "Roboto", sans-serif;
-  font-weight: 500;
+  font-weight: 400;
   font-style: normal;
 }
 

--- a/_sass/world/2024/base/_body.scss
+++ b/_sass/world/2024/base/_body.scss
@@ -1,7 +1,33 @@
 html {
+  overflow-x: hidden;
+}
+
+// Fonts are only able to be udpated here for some reason.
+h1,
+h2,
+h3,
+h4,
+h5 {
   font-family: "acumin-variable", sans-serif;
   font-variation-settings: var(--font-weight-700);
-  overflow-x: hidden;
+}
+
+p {
+  font-family: "Roboto", sans-serif;
+  font-weight: 500;
+  font-style: normal;
+}
+
+a,
+button {
+  font-family: "Roboto", sans-serif;
+  font-weight: 900;
+  font-style: italic;
+  letter-spacing: 1px;
+
+  @media screen and (max-width: 800px){
+    letter-spacing: 0.5px;
+  }
 }
 
 body {

--- a/_sass/world/2024/base/_body.scss
+++ b/_sass/world/2024/base/_body.scss
@@ -1,5 +1,5 @@
 html {
-  overflow-x: hidden;
+  scroll-padding-top: 85px;
 }
 
 // Fonts are only able to be udpated here for some reason.
@@ -51,4 +51,5 @@ body {
   display: flex;
   justify-content: center;
   width: 100%;
+  overflow-x: hidden;
 }

--- a/_sass/world/2024/base/_metrics.scss
+++ b/_sass/world/2024/base/_metrics.scss
@@ -7,6 +7,7 @@
   --space-x-large: 3em;
   --space-xx-large: 4em;
   --space-xxx-large: 6em;
+  --space-xxxx-large: 10em;
 
   /* Font size modular scale */
   --type-base: calc(1.6em + 0.5vw);

--- a/_sass/world/2024/base/_typography.scss
+++ b/_sass/world/2024/base/_typography.scss
@@ -9,6 +9,7 @@
 }
 
 h1 {
+  font-family: "acumin-variable", sans-serif;
   color: var(--text-color);
   font-size: var(--type-xxx-large);
   font-variation-settings: var(--font-weight-800);
@@ -21,6 +22,7 @@ h1 {
 }
 
 h2 {
+  font-family: "acumin-variable", sans-serif;
   color: var(--text-color);
   font-size: var(--type-xx-large);
   font-variation-settings: var(--font-weight-800);
@@ -33,6 +35,7 @@ h2 {
 }
 
 h3 {
+  font-family: "acumin-variable", sans-serif;
   color: var(--text-color);
   font-size: var(--type-x-large);
   font-variation-settings: var(--font-weight-800);
@@ -45,6 +48,7 @@ h3 {
 }
 
 h4 {
+  font-family: "acumin-variable", sans-serif;
   color: var(--text-color);
   font-size: var(--type-large);
 
@@ -55,6 +59,7 @@ h4 {
 }
 
 h5 {
+  font-family: "acumin-variable", sans-serif;
   color: var(--text-color);
   font-size: var(--type-medium);
 
@@ -65,6 +70,7 @@ h5 {
 }
 
 h6 {
+  font-family: "acumin-variable", sans-serif;
   color: var(--text-color);
   font-size: var(--type-small);
 
@@ -75,21 +81,17 @@ h6 {
 }
 
 p {
+  font-family: Roboto;
+  font-style: normal;
   color: var(--text-color);
-  line-height: 150%;
-  font-variation-settings: var(--font-weight-600);
+  line-height: 1.3;
 
   /* Extra small devices (phones, 600px and down) */
   @media only screen and (max-width: 600px) {
     font-size: var(--type-small);
-    font-variation-settings: var(--font-weight-400);
   }
 }
 
 strong {
   font-weight: 800;
-}
-
-em {
-  font-style: italic;
 }

--- a/_sass/world/2024/base/_variables.scss
+++ b/_sass/world/2024/base/_variables.scss
@@ -1,6 +1,8 @@
 :root {
+    --larger-desktop-padding: var(--space-large) var(--space-xxxx-large);
     --desktop-padding: var(--space-large) var(--space-xxx-large);
     --mobile-padding:  var(--space-medium) var(--space-large);
+    --smaller-mobile-padding: var(--space-medium) var(--space-medium);
 }
 
 $filter-dark-purple: brightness(0) saturate(100%) invert(17%) sepia(34%) saturate(1978%) hue-rotate(238deg) brightness(95%) contrast(98%);

--- a/_sass/world/2024/common/_button.scss
+++ b/_sass/world/2024/common/_button.scss
@@ -67,6 +67,7 @@
     border-radius: 50%;
     background-color: var(--white);
     opacity: 0.8;
+    touch-action: manipulation;
 
     &.active {
         background-color: var(--red);
@@ -87,6 +88,7 @@
     background-color: var(--red);
     color: var(--white);
     opacity: 0.8;
+    touch-action: manipulation;
 
     .arrowSvg {
         width: 40%;

--- a/_sass/world/2024/common/_button.scss
+++ b/_sass/world/2024/common/_button.scss
@@ -6,7 +6,6 @@
     cursor: pointer;
     text-decoration: none;
     transition: box-shadow 0.15s ease;
-    // font-style: normal;
     transition: all 0.15s ease;
 
     &:hover {
@@ -22,7 +21,6 @@
 .button.main {
     background: var(--red);
     color: var(--white);
-    // font-weight: var(--font-weight-400);
     text-transform: uppercase;
 
     &:hover {

--- a/_sass/world/2024/common/_button.scss
+++ b/_sass/world/2024/common/_button.scss
@@ -5,10 +5,8 @@
     color: var(--black);
     cursor: pointer;
     text-decoration: none;
-    font-weight: var(--font-weight-800);
-    font-size: var(--type-medium);
     transition: box-shadow 0.15s ease;
-    font-style: normal;
+    // font-style: normal;
     transition: all 0.15s ease;
 
     &:hover {
@@ -24,7 +22,7 @@
 .button.main {
     background: var(--red);
     color: var(--white);
-    font-weight: var(--font-weight-400);
+    // font-weight: var(--font-weight-400);
     text-transform: uppercase;
 
     &:hover {

--- a/_sass/world/2024/modules/_announcements.scss
+++ b/_sass/world/2024/modules/_announcements.scss
@@ -1,6 +1,5 @@
 .announcements {
     background-color: var(--red);
-    // background-color: green;
     width: 100%;
     display: flex;
     align-items: center;
@@ -10,7 +9,6 @@
     font-size: var(--type-x-small);
 
     .textContainer {
-        // background-color: cyan;
         width: 95%;
         display: flex;
         align-items: center;

--- a/_sass/world/2024/modules/_announcements.scss
+++ b/_sass/world/2024/modules/_announcements.scss
@@ -7,6 +7,7 @@
     justify-content: center;
     padding: 10px 0;
     border-bottom: var(--border-style);
+    font-size: var(--type-x-small);
 
     .textContainer {
         // background-color: cyan;
@@ -18,16 +19,24 @@
         p {
             text-align: center;
             color: var(--white);
-            font-size: var(--type-x-small);
-
-            @media screen and (max-width: 500px){
-                font-size: var(--type-xxx-small);
-            }
+            font-weight: 700;
         }
     }
 
     a {
+        font-family: "Roboto";
+        font-weight: 700;
         font-style: normal;
         color: var(--white);
+        transition: all 0.2s ease;
+
+        &:hover {
+            text-shadow: 0px 4px 3px rgba(0, 0, 0, 0.3);
+        }
+    }
+
+
+    @media screen and (max-width: 500px) {
+        font-size: var(--type-xx-small);
     }
 }

--- a/_sass/world/2024/modules/_announcements.scss
+++ b/_sass/world/2024/modules/_announcements.scss
@@ -1,19 +1,33 @@
 .announcements {
     background-color: var(--red);
+    // background-color: green;
     width: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
-    padding-top: 5px;
-    padding-bottom: 5px;
+    padding: 10px 0;
     border-bottom: var(--border-style);
 
-    p {
-        color: var(--white);
-        font-size: var(--type-xx-small);
+    .textContainer {
+        // background-color: cyan;
+        width: 95%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        p {
+            text-align: center;
+            color: var(--white);
+            font-size: var(--type-x-small);
+
+            @media screen and (max-width: 500px){
+                font-size: var(--type-xxx-small);
+            }
+        }
     }
 
     a {
+        font-style: normal;
         color: var(--white);
     }
 }

--- a/_sass/world/2024/modules/_faq.scss
+++ b/_sass/world/2024/modules/_faq.scss
@@ -80,6 +80,7 @@ details summary::-webkit-details-marker {
                     .summaryQuestion {
                         font-size: var(--type-medium);
                         line-height: 1.15;
+                        font-weight: 500;
                     }
                 }
 
@@ -151,8 +152,22 @@ details summary::-webkit-details-marker {
     z-index: 100;
     position: relative;
 
-    @media screen and (max-width: 800px) {
+    @media only screen and (max-width: 800px) {
         padding: var(--mobile-padding);
+        padding-top: var(--space-x-small);
+        padding-bottom: var(--space-x-small);
+    }
+
+    // Actual phone
+    @media only screen and (max-width: 500px) {
+        padding: var(--smaller-mobile-padding);
+        padding-top: var(--space-x-small);
+        padding-bottom: var(--space-x-small);
+    }
+
+    // Larger Desktop 
+    @media only screen and (min-width: 1550px) {
+        padding: var(--larger-desktop-padding);
         padding-top: var(--space-x-small);
         padding-bottom: var(--space-x-small);
     }

--- a/_sass/world/2024/modules/_faq.scss
+++ b/_sass/world/2024/modules/_faq.scss
@@ -34,6 +34,7 @@ details summary::-webkit-details-marker {
             display: flex;
             flex-direction: column;
             gap: var(--space-small);
+            padding-top: 10px;
         }
 
         h2 {
@@ -50,16 +51,12 @@ details summary::-webkit-details-marker {
             details {
                 transition: all 0.15s ease-in;
 
-                svg {
-                    width: 100px;
-                }
-
                 summary {
                     cursor: pointer;
                     border: var(--border-style);
                     border-radius: 5px;
                     color: var(--white);
-                    padding: var(--space-small);
+                    padding: var(--space-x-small) var(--space-small);
                     display: flex;
                     justify-content: flex-start;
                     align-items: center;
@@ -73,10 +70,16 @@ details summary::-webkit-details-marker {
                         filter: invert(1);
                         transform: rotate(90deg);
                         transition: transform 0.2s linear;
+
+                        @media screen and (max-width: 800px) {
+                            width: 20px;
+                            min-width: 20px;
+                            max-width: 20px;
+                        }
                     }
 
                     .summaryQuestion {
-                        font-size: var(--type-large);
+                        font-size: var(--type-medium);
                     }
                 }
 
@@ -86,11 +89,12 @@ details summary::-webkit-details-marker {
                     color: var(--black);
                     background-color: var(--white);
                     border-radius: 0 0 5px 5px;
-                    font-size: var(--type-x-small);
-                    padding: var(--space-medium);
+                    font-size: var(--type-small);
+                    padding: var(--space-small) var(--space-medium);
                     gap: 5px;
 
                     a {
+                        font-style: normal;
                         color: var(--purple);
                     }
                 }
@@ -115,6 +119,16 @@ details summary::-webkit-details-marker {
 
         @media only screen and (max-width: 800px) {
             padding: var(--mobile-padding);
+        }
+    
+        // Actual phone
+        @media only screen and (max-width: 500px) {
+            padding: var(--smaller-mobile-padding);
+        }
+    
+        // Larger Desktop 
+        @media only screen and (min-width: 1550px) {
+            padding: var(--larger-desktop-padding);
         }
     }
 }

--- a/_sass/world/2024/modules/_faq.scss
+++ b/_sass/world/2024/modules/_faq.scss
@@ -32,9 +32,8 @@ details summary::-webkit-details-marker {
 
         .categoryContainer {
             display: flex;
+            gap: 5px;
             flex-direction: column;
-            gap: var(--space-small);
-            padding-top: 10px;
         }
 
         h2 {
@@ -80,6 +79,7 @@ details summary::-webkit-details-marker {
 
                     .summaryQuestion {
                         font-size: var(--type-medium);
+                        line-height: 1.15;
                     }
                 }
 
@@ -93,9 +93,14 @@ details summary::-webkit-details-marker {
                     padding: var(--space-small) var(--space-medium);
                     gap: 5px;
 
+                    //Desktop size
                     a {
                         font-style: normal;
                         color: var(--purple);
+                    }
+
+                    @media screen and (min-width: 800px) {
+                        font-size: var(--type-x-small);
                     }
                 }
 
@@ -143,6 +148,8 @@ details summary::-webkit-details-marker {
     padding: var(--desktop-padding);
     padding-top: var(--space-small);
     padding-bottom: var(--space-small);
+    z-index: 100;
+    position: relative;
 
     @media screen and (max-width: 800px) {
         padding: var(--mobile-padding);
@@ -155,7 +162,8 @@ details summary::-webkit-details-marker {
         display: flex;
         justify-content: start;
         overflow-x: scroll;
-        padding: var(--mobile-padding);
+        padding: var(--smaller-mobile-padding);
+        padding-left: 2px;
 
         .categoryButton {
             display: flex;

--- a/_sass/world/2024/modules/_faq.scss
+++ b/_sass/world/2024/modules/_faq.scss
@@ -55,7 +55,7 @@ details summary::-webkit-details-marker {
                     border: var(--border-style);
                     border-radius: 5px;
                     color: var(--white);
-                    padding: var(--space-x-small) var(--space-small);
+                    padding: var(--space-small);
                     display: flex;
                     justify-content: flex-start;
                     align-items: center;

--- a/_sass/world/2024/modules/_footer.scss
+++ b/_sass/world/2024/modules/_footer.scss
@@ -131,6 +131,17 @@ footer {
                 width: 80%;
                 justify-content: center;
                 gap: 15px;
+
+                a {
+                    font-size: 0.9rem;
+                }
+            }
+
+            @media only screen and (max-width: 500px) {
+                a {
+                    white-space: nowrap;
+                    font-size: 0.7rem;
+                }
             }
         }
 

--- a/_sass/world/2024/modules/_footer.scss
+++ b/_sass/world/2024/modules/_footer.scss
@@ -1,4 +1,5 @@
 footer {
+    overflow-x: hidden;
     display: flex;
     height: 85px;
     width: 100%;
@@ -48,24 +49,28 @@ footer {
         height: 100%;
         border-right: var(--border-style);
 
-        .socialLinks {
+        .linksContainer {
             display: flex;
             align-items: center;
             justify-content: center;
             height: 100%;
-            gap: 15px;
 
-            a {
-                svg {
-                    width: 25px;
-                    fill: var(--white);
-                    transition: all 0.2s ease;
-                }
+            .socialLinks {
+                display: flex;
+                gap: 15px;
 
-                &:hover {
+                a {
                     svg {
-                        fill: var(--red);
-                        transform: translateY(-1px);
+                        width: 25px;
+                        fill: var(--white);
+                        transition: all 0.2s ease;
+                    }
+
+                    &:hover {
+                        svg {
+                            fill: var(--red);
+                            transform: translateY(-1px);
+                        }
                     }
                 }
             }
@@ -77,8 +82,10 @@ footer {
         }
 
         @media screen and (max-width: 800px) {
-            .socialLinks {
-                gap: 5px;
+            .linksContainer {
+                .socialLinks {
+                    gap: 5px;
+                }
             }
         }
     }
@@ -162,12 +169,14 @@ footer {
     }
 
     @media only screen and (max-width: 800px) {
+        padding-left: 0;
+
         .sideContainer {
-            width: 120px;
+            width: 18%;
         }
 
         .center {
-            width: 400px;
+            width: 60%;
         }
     }
 }

--- a/_sass/world/2024/modules/_header.scss
+++ b/_sass/world/2024/modules/_header.scss
@@ -1,9 +1,9 @@
 $headerHeight: 80px;
 
 header {
-    position: sticky;
+    position: sticky !important;
     top: 0;
-    z-index: 10;
+    z-index: 900 !important;
     width: 100%;
 
     #desktopHeader {

--- a/_sass/world/2024/modules/_landing_page.scss
+++ b/_sass/world/2024/modules/_landing_page.scss
@@ -1,6 +1,7 @@
 .landing-page {
     width: 100%;
     position: relative;
+    overflow-x: hidden;
 }
 
 .content-container {
@@ -124,10 +125,6 @@
             align-items: center;
             justify-content: space-between;
             width: 105%;
-
-            @media only screen and (max-width: 800px) {
-                width: 100%;
-            }
         }
 
         .slide {

--- a/_sass/world/2024/modules/_landing_page.scss
+++ b/_sass/world/2024/modules/_landing_page.scss
@@ -1,5 +1,6 @@
 .landing-page {
     width: 100%;
+    position: relative;
 }
 
 .content-container {
@@ -10,6 +11,16 @@
 
     @media only screen and (max-width: 800px) {
         padding: var(--mobile-padding);
+    }
+
+    // Actual phone
+    @media only screen and (max-width: 500px) {
+        padding: var(--smaller-mobile-padding);
+    }
+
+    // Larger Desktop 
+    @media only screen and (min-width: 1550px) {
+        padding: var(--larger-desktop-padding);
     }
 }
 

--- a/world/2023/faq.html
+++ b/world/2023/faq.html
@@ -1,7 +1,6 @@
 ---
 layout: world/2023/default
 permalink: /world/2023/faq
-redirect_from: /world/faq
 title: Frequently Asked Questions
 ---
 

--- a/world/2024/faq.html
+++ b/world/2024/faq.html
@@ -1,7 +1,7 @@
 ---
 layout: world/2024/default
 permalink: /world/2024/faq
-<!-- redirect_from: /world/faq -->
+redirect_from: /world/faq
 title: Frequently Asked Questions
 ---
 
@@ -53,24 +53,14 @@ assign faqData = site.data.world['2024'].faq %} {% assign categories = faqData |
 
 </div>
 
-<!-- Script to adjust the scrollTo based of header height -->
+<!-- Script to focus category after clicking -->
 <script>
     const allATags = document.getElementsByClassName('categoryButton');
 
     for (let i = 0; i < allATags.length; i++) {
         allATags[i].addEventListener('click', function (event) {
-            event.preventDefault();
-
             const targetId = allATags[i].getAttribute('href');
             const targetElement = document.querySelector(targetId);
-
-            const headerHeight = document.getElementById('header-2024').offsetHeight;
-            const targetPosition = targetElement.offsetTop - headerHeight - 5;
-
-            window.scrollTo({
-                top: targetPosition,
-                behavior: 'smooth'
-            });
 
             // Set focus for accessibility users
             targetElement.focus();

--- a/world/2024/faq.html
+++ b/world/2024/faq.html
@@ -50,7 +50,6 @@ assign faqData = site.data.world['2024'].faq %} {% assign categories = faqData |
         </section>
         {% endfor %}
     </section>
-
 </div>
 
 <!-- Script to focus category after clicking -->


### PR DESCRIPTION
## Why?
This first version I saw had a lot of things I could polish. 

## What's changed?
- Larger margins for desktop / Smaller margins for mobile 
- No italic font everywhere - switched it out for Roboto 
- More accessible slideshow / increase lighthouse scores
- FAQ updates:
   - Better scrolling when clicking a category
   - Smaller font used (fit more content inside the frame)
   - Other padding changes to make consistent
- Other general padding/consistency updates
- Fix sticky header (accidentally broke it on release)
- Mobile footer tweaks

## What's next
I'm sure we will find more things to polish, which I think would be best to do for the next main update with sponsors (end of April). Unless there are major breaking changes that need to be done.

## Misc Images of changes
<img width="1800" alt="SCR-20240403-rspo" src="https://github.com/rails/website/assets/78773266/65e4b8b9-548c-4dc3-be42-4f4371113bc2">
<img width="571" alt="SCR-20240403-rstt" src="https://github.com/rails/website/assets/78773266/41067852-6621-43ba-b888-f599a2ea933d">
<img width="902" alt="SCR-20240403-rsze" src="https://github.com/rails/website/assets/78773266/3c5c7628-37b1-4042-b5f8-a6a95608174f">
<img width="439" alt="SCR-20240403-rtge" src="https://github.com/rails/website/assets/78773266/2fc4e5d5-9cce-445c-9f4a-31c2c33a8c57">
<img width="441" alt="SCR-20240403-rtjn" src="https://github.com/rails/website/assets/78773266/fd99fe22-7c7b-4a45-84c2-b66fa36d4027">
<img width="449" alt="SCR-20240403-ruxi" src="https://github.com/rails/website/assets/78773266/6d851b36-1844-41c3-9404-9aaa4c7c1b6f">
