### PR TITLE
Fix: Codeblock contrast issue on system dark mode

### DIFF
--- a/_sass/common/_content.scss
+++ b/_sass/common/_content.scss
@@ -344,7 +344,7 @@
 
 @media (prefers-color-scheme: dark) {
   pre, code {
-    background-color: $color-grey-1;
+    background-color: none;
     color: #fff;
   } // pre, code
 


### PR DESCRIPTION
We recently updated the styling in https://github.com/rails/website/pull/266 for using the same highlight theme in codeblocks. Due to this change the codeblock is getting a contrast issue on dark mode.
<img width="951" alt="Screenshot 2024-04-25 at 2 15 25 PM" src="https://github.com/rails/website/assets/22231095/ca20ac90-453f-45bb-9ed1-923920656ad4">

cc/ @gregmolnar @AmandaPerino 