### PR TITLE
Adjust speaker section CSS - Rails World

### DIFF
--- a/_sass/world/2024/modules/_landing_page.scss
+++ b/_sass/world/2024/modules/_landing_page.scss
@@ -54,8 +54,9 @@
         }
     }
 
+    // Push down to avoid the circle svg cutting off border
     @media only screen and (min-width: 1400px) {
-        margin-bottom: 20px;
+        margin-bottom: 35px;
     }
 }
 

--- a/_sass/world/2024/modules/_speakers.scss
+++ b/_sass/world/2024/modules/_speakers.scss
@@ -8,7 +8,7 @@
     .headerContainer {
         display: flex;
         align-items: center;
-        justify-content: center;
+        justify-content: flex-start;
 
         .textContainer {
             display: flex;
@@ -79,9 +79,5 @@
         scroll-snap-points-x: repeat(100%);
         scroll-snap-stop: always;
         -webkit-overflow-scrolling: touch;
-
-        @media screen and (min-width: 650px) {
-          justify-content: center;
-        }
     }
 }

--- a/_sass/world/2024/modules/_speakers.scss
+++ b/_sass/world/2024/modules/_speakers.scss
@@ -80,4 +80,24 @@
         scroll-snap-stop: always;
         -webkit-overflow-scrolling: touch;
     }
+
+    @media screen and (min-width: 1350px) {
+        .headerContainer {
+            justify-content: center;
+
+            .textContainer {
+                align-items: center;
+
+                p {
+                    text-align: center;
+                }
+            }
+        }
+
+        .cardsContainer {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+    }
 }

--- a/_sass/world/2024/modules/_speakers.scss
+++ b/_sass/world/2024/modules/_speakers.scss
@@ -81,6 +81,7 @@
         -webkit-overflow-scrolling: touch;
     }
 
+    // Centering for four speakers (need to change if speakers change)
     @media screen and (min-width: 1350px) {
         .headerContainer {
             justify-content: center;


### PR DESCRIPTION
## The Problem 
Two things I noticed with the PR that added the speaker section and landing page. When at a certain width the first card is cut off, and the title and description don't match other existing titles and descriptions. 

## My Reasoning
I see what the intent was (to make it centered when the page is larger & there is no overflow), So I just updated this approach to better relate to the current design elements being used. 

I found the exact width the speakers start to over-flow and set that point to trigger it going back to being left aligned (fixes the bug). 

I also updated the text when it's centered to make that also centered. 

## Image of bug
<img width="985" alt="SCR-20240427-ttbv" src="https://github.com/rails/website/assets/78773266/2dec1063-6eeb-43d1-bd96-afd7f7c03b16">

## Images of fix
<img width="1247" alt="SCR-20240427-ubrg" src="https://github.com/rails/website/assets/78773266/ce13e89a-9940-47c2-9ffa-7d03d3b11b5c">
<img width="1025" alt="SCR-20240427-ubsr" src="https://github.com/rails/website/assets/78773266/9ef7322e-ea3e-4d98-a66e-3178d415d8d6">
