### PR TITLE
Update speakers description width - Rails World 2024

### DIFF
--- a/_includes/world/2024/sections/speakers.html
+++ b/_includes/world/2024/sections/speakers.html
@@ -1,7 +1,7 @@
 {% assign sorted_speakers = site.world_speakers | where_exp: 'item', 'item.path contains "2024"' | sort: 'last_name' %}
 {% assign keynote_speakers = sorted_speakers | where: 'keynote', true %}
-{% assign non_keynote_speakers = sorted_speakers | where_exp: "speaker", "speaker.keynote != true" | sort: "first_name"
-%}
+{% assign non_keynote_speakers = sorted_speakers | where_exp: "speaker", "speaker.keynote != true" | sort: "first_name" %}
+
 
 <section class="content-container speaker-cards">
     <div class="headerContainer">
@@ -23,24 +23,24 @@
     </div>
     <div class="cardsContainer">
         {% for speaker in keynote_speakers %}
-        {%
-        include world/2024/speaker-card.html
-        first_name=speaker.first_name
-        last_name=speaker.last_name
-        role=speaker.role
-        company=speaker.company
-        photo=speaker.image_path
-        %}
+            {%
+            include world/2024/speaker-card.html
+            first_name=speaker.first_name
+            last_name=speaker.last_name
+            role=speaker.role
+            company=speaker.company
+            photo=speaker.image_path
+            %}
         {% endfor %}
         {% for speaker in non_keynote_speakers %}
-        {%
-        include world/2024/speaker-card.html
-        first_name=speaker.first_name
-        last_name=speaker.last_name
-        role=speaker.role
-        company=speaker.company
-        photo=speaker.image_path
-        %}
+            {%
+            include world/2024/speaker-card.html
+            first_name=speaker.first_name
+            last_name=speaker.last_name
+            role=speaker.role
+            company=speaker.company
+            photo=speaker.image_path
+            %}
         {% endfor %}
     </div>
 </section>

--- a/_includes/world/2024/sections/speakers.html
+++ b/_includes/world/2024/sections/speakers.html
@@ -1,44 +1,46 @@
 {% assign sorted_speakers = site.world_speakers | where_exp: 'item', 'item.path contains "2024"' | sort: 'last_name' %}
 {% assign keynote_speakers = sorted_speakers | where: 'keynote', true %}
-{% assign non_keynote_speakers = sorted_speakers | where_exp: "speaker", "speaker.keynote != true" | sort: "first_name" %}
+{% assign non_keynote_speakers = sorted_speakers | where_exp: "speaker", "speaker.keynote != true" | sort: "first_name"
+%}
 
 <section class="content-container speaker-cards">
     <div class="headerContainer">
         <div class="textContainer">
             <h3>Keynote Speakers</h3>
             <p>
-                Gain invaluable insights from our four keynote speakers on the present landscape of Rails and where Rails is headed tomorrow and beyond. More speakers announced soon.
+                Gain invaluable insights from our four keynote speakers on the present landscape of Rails and where
+                Rails is headed tomorrow and beyond. More speakers announced soon.
             </p>
         </div>
-    <!-- <div class="buttonsContainer">
+        <div class="buttonsContainer">
             <button alt="Left Arrow" id="leftBtn" aria-label="scroll carousel backward">
                 <img alt="Left Arrow" src="/assets/world/2023/previous.svg">
             </button>
             <button alt="Right Arrow" id="rightBtn" aria-label="scroll carousel forward">
                 <img alt="Right Arrow" src="/assets/world/2023/next.svg">
             </button>
-        </div> -->
+        </div>
     </div>
     <div class="cardsContainer">
         {% for speaker in keynote_speakers %}
-            {%
-            include world/2024/speaker-card.html
-            first_name=speaker.first_name 
-            last_name=speaker.last_name
-            role=speaker.role
-            company=speaker.company
-            photo=speaker.image_path
-            %}
+        {%
+        include world/2024/speaker-card.html
+        first_name=speaker.first_name
+        last_name=speaker.last_name
+        role=speaker.role
+        company=speaker.company
+        photo=speaker.image_path
+        %}
         {% endfor %}
         {% for speaker in non_keynote_speakers %}
-            {%
-            include world/2024/speaker-card.html
-            first_name=speaker.first_name 
-            last_name=speaker.last_name
-            role=speaker.role
-            company=speaker.company
-            photo=speaker.image_path
-            %}
+        {%
+        include world/2024/speaker-card.html
+        first_name=speaker.first_name
+        last_name=speaker.last_name
+        role=speaker.role
+        company=speaker.company
+        photo=speaker.image_path
+        %}
         {% endfor %}
     </div>
 </section>

--- a/_sass/world/2024/modules/_speakers.scss
+++ b/_sass/world/2024/modules/_speakers.scss
@@ -1,3 +1,4 @@
+// Replace existing code with // ! code - when more than 4 speakers
 .speaker-cards {
     display: flex;
     flex-direction: column;
@@ -16,7 +17,9 @@
             align-items: flex-start;
             justify-content: center;
             gap: var(--header-and-paragraph-padding);
-            width: 85%;
+
+            width: 100%;
+            // ! width: 85%;
 
             p {
                 text-align: start;
@@ -28,7 +31,9 @@
         }
 
         .buttonsContainer {
-            display: flex;
+            display: none;
+            // ! display: flex;
+
             align-items: flex-end;
             justify-content: flex-end;
             gap: 15px;
@@ -81,7 +86,8 @@
         -webkit-overflow-scrolling: touch;
     }
 
-    // Centering for four speakers (need to change if speakers change)
+    // ! Centering for four speakers
+    // ! Remove this whole media query when more than 4 speakers
     @media screen and (min-width: 1350px) {
         .headerContainer {
             justify-content: center;


### PR DESCRIPTION
## The Problem 
The description still was sized as if the buttons weren't commented out 
<img width="571" alt="SCR-20240429-owni" src="https://github.com/rails/website/assets/78773266/30d81e81-1ffa-4bb2-90da-9b41d5e2ebfa">

## The Solution 
Fix this width issue 
<img width="567" alt="SCR-20240429-owpb" src="https://github.com/rails/website/assets/78773266/b6d8dd41-8bdf-4e37-a811-02c0e113147a">


## Other Changes 
I added comments to show what will need to be removed when there are more than 4 speakers.