### PR TITLE
Update Miles Woodroffe profile

### DIFF
--- a/_pages/foundation.html
+++ b/_pages/foundation.html
@@ -133,7 +133,7 @@ permalink: /foundation
           <li><a href="https://www.linkedin.com/in/brunomiranda/">Bruno Miranda</a> (SVP, Engineering, Doximity)</li>
           <li><a href="https://www.linkedin.com/in/ryansherlock/">Ryan Sherlock</a> (Director of Engineering, Intercom)</li>
           <li><a href="https://www.linkedin.com/in/valdivia-dev/">Jorge Valdivia</a> (CTO, Fleetio)</li>
-          <li><a href="https://www.linkedin.com/in/tapster/">Miles Woodroffe</a> (Global CTO, Cookpad)</li>
+          <li><a href="https://www.linkedin.com/in/tapster/">Miles Woodroffe</a> (CTO, Mindful Chef)</li>
         </ul>
 
         <hr class="divider" />


### PR DESCRIPTION
Miles left Cookpad and joined Mindful Chef in November 2023: https://www.linkedin.com/in/tapster/

I was browsing the foundation page and noticed that he's still listed as CTO of Cookpad Global, so this PR fixes it.

@tapster please let me know if this looks good to you, or if we should mention a different role/company for your profile. Thanks!