### PR TITLE
Rails World 2024 - Quick session/speaker touch ups

### DIFF
--- a/_includes/world/2024/sections/speakers.html
+++ b/_includes/world/2024/sections/speakers.html
@@ -1,9 +1,13 @@
 {% assign sorted_speakers = site.world_speakers | where_exp: 'item', 'item.path contains "2024"' | sort: 'last_name' %}
-{% assign keynote_speakers = sorted_speakers | where: 'keynote', true %}
-{% assign non_keynote_speakers = sorted_speakers | where_exp: "speaker", "speaker.keynote != true" | sort: "first_name"
-%}
 
+{% assign specific_order_speakers = sorted_speakers | where_exp: 'item', 'item.specific_order != null' | sort: 'specific_order' %}
 
+{% assign remaining_speakers = sorted_speakers | where_exp: 'item', 'item.specific_order == null' %}
+
+{% assign keynote_speakers = remaining_speakers | where: 'keynote', true %}
+{% assign non_keynote_speakers = remaining_speakers | where_exp: "speaker", "speaker.keynote != true" | sort: "first_name" %}
+    
+    
 <section class="content-container speaker-cards">
     <div class="headerContainer">
         <div class="textContainer">
@@ -23,6 +27,17 @@
         </div>
     </div>
     <div class="cardsContainer">
+        {% for speaker in specific_order_speakers %}
+        {%
+        include world/2024/speaker-card.html
+        first_name=speaker.first_name
+        last_name=speaker.last_name
+        role=speaker.role
+        company=speaker.company
+        photo=speaker.image_path
+        path=speaker.path
+        %}
+        {% endfor %}
         {% for speaker in keynote_speakers %}
         {%
         include world/2024/speaker-card.html

--- a/_includes/world/2024/tito-widget.html
+++ b/_includes/world/2024/tito-widget.html
@@ -2,11 +2,12 @@
     <h3 class="ticketTitle">Tickets</h3>
     <div class="iframeContainer">
         <div id="tito-widget"></div>
-        <div class="soldOutContainer">
+        <!-- Bring back after no more sale -->
+        <!-- <div class="soldOutContainer">
             <p>
                 Sold out. If tickets are returned or released we will release another batch later this year.
             </p>
-        </div>
+        </div> -->
     </div>
 </div>
 <script>
@@ -15,7 +16,6 @@
         ? "ultimateconf/2013"
         : "rails-world/rails-world-2024";
 
-    // Add this back if tickets go back on sale
-    // window.tito = window.tito || function () { (tito.q = tito.q || []).push(arguments); };
-    // tito("widget.mount", { el: "#tito-widget", event })
+    window.tito = window.tito || function () { (tito.q = tito.q || []).push(arguments); };
+    tito("widget.mount", { el: "#tito-widget", event })
 </script>

--- a/_layouts/world/2024/speaker.html
+++ b/_layouts/world/2024/speaker.html
@@ -50,12 +50,17 @@ layout: world/2024/default
                         <h3>Session</h3>
                         {% for session in speakerSessions %}
                         {% assign sessionUrl = session.path | split: '/' | last | remove_first: '.md' %}
-                        {% assign hasInfo = session.time != blank and session.session_date != blank and session.location != blank %}
+                        {% if session.time != blank and session.session_date != blank and session.location != blank %}
+                            {% assign hasInfo = true %}
+                        {% else %}
+                            {% assign hasInfo = false %}
+                        {% endif %}
+
                         {% if hasInfo %}
                             {% assign className = "sessionCard" %}
                         {% else %}
                             {% assign className = "sessionCard noInfo" %}
-                        {% endif %}                        
+                        {% endif %}
                         <div class="{{ className }}" href="" role="button" tabindex="0" title="{{ session.title }}"
                             aria-label="Go to {{ session.title }} session page" onclick="openWindow(
                                 '/world/2024/session/{{ sessionUrl }}'

--- a/_sass/world/2024/modules/_session.scss
+++ b/_sass/world/2024/modules/_session.scss
@@ -2,7 +2,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 40px 0px;
+    padding: 45px 0px;
     width: 100%;
     height: 100%;
     flex: 1;
@@ -11,7 +11,7 @@
         position: relative;
         background-color: var(--white);
         width: 85%;
-        max-width: 1700px;
+        max-width: 1300px;
         display: flex;
         border-radius: 15px;
         flex-direction: column;
@@ -20,7 +20,7 @@
             position: absolute;
             left: 0;
             top: 0;
-            margin-top: -40px;
+            margin-top: -41px;
             height: 40px;
             display: flex;
             align-items: center;
@@ -58,15 +58,16 @@
             align-items: flex-start;
             justify-content: center;
             flex-direction: column;
-            gap: 15px;
+            gap: 10px;
             padding: 25px 25px;
 
             .sessionTitle {
                 color: var(--red);
             }
 
-            .description {}
-
+            p {
+                line-height: 1.4;
+            }
 
             .informationContainer {
                 display: flex;
@@ -218,6 +219,8 @@
                             height: 300px;
                             will-change: box-shadow;
                             transition: 0.4s ease;
+                            object-fit: cover;
+                            object-position: center;
 
                             // desktop 
                             @media screen and (max-width: 950px) {

--- a/_world_speakers/2024/speakers/aaron-patterson.md
+++ b/_world_speakers/2024/speakers/aaron-patterson.md
@@ -9,6 +9,7 @@ keynote: true
 github: https://github.com/tenderlove
 linkedin: https://www.linkedin.com/in/tenderlove/
 twitter: https://twitter.com/tenderlove
+specific_order: 0
 ---
 
 Aaron is on the Rails core team, the Ruby core team, and is a Senior Staff Engineer working at Shopify. In his free time, he enjoys cooking, playing with cats, and writing weird software.

--- a/_world_speakers/2024/speakers/david-hansson.md
+++ b/_world_speakers/2024/speakers/david-hansson.md
@@ -9,6 +9,7 @@ keynote: true
 github: https://github.com/dhh
 linkedin: https://www.linkedin.com/in/david-heinemeier-hansson-374b18221/
 twitter: https://twitter.com/dhh
+specific_order: 1
 ---
 
 Creator of Ruby on Rails.

--- a/_world_speakers/2024/speakers/eileen-uchitelle.md
+++ b/_world_speakers/2024/speakers/eileen-uchitelle.md
@@ -9,6 +9,7 @@ keynote: true
 github: https://github.com/eileencodes
 linkedin: https://www.linkedin.com/in/eileencodes/
 twitter: https://twitter.com/eileencodes
+specific_order: 2
 ---
 
 Eileen M. Uchitelle is a Senior Staff Engineer at Shopify where she helps lead the effort to improve and maintain the Rails framework and Ruby language. Her approach to solving technical problems centers around ensuring the continued stability and extensibility for individual developers and companies large and small. As a member of the Rails Core Team her goal is to ensure the long-term sustainability of the Rails framework and its continued adoption as one of the leading open-source frameworks.

--- a/_world_speakers/2024/speakers/rafael-franca.md
+++ b/_world_speakers/2024/speakers/rafael-franca.md
@@ -9,6 +9,7 @@ keynote: false
 github: https://github.com/rafaelfranca
 linkedin: https://www.linkedin.com/in/rafaelmfranca/
 twitter: https://twitter.com/rafaelfranca
+specific_order: 4
 ---
 
 Rails Core member and technical leader in the Ruby and Rails infrastructure team at Shopify.

--- a/_world_speakers/2024/speakers/tobias-lutke.md
+++ b/_world_speakers/2024/speakers/tobias-lutke.md
@@ -9,6 +9,7 @@ keynote: true
 github: https://github.com/tobi
 linkedin: https://www.linkedin.com/in/tobiaslutke/
 twitter: https://twitter.com/tobi
+specific_order: 3
 ---
 
 Shopify CEO by day, Dad in evening, hacker at night.

--- a/_world_speakers/2024/speakers/xavier-noria.md
+++ b/_world_speakers/2024/speakers/xavier-noria.md
@@ -9,6 +9,7 @@ keynote: false
 github: https://github.com/fxn
 linkedin: https://www.linkedin.com/in/xaviernoria/
 twitter: https://twitter.com/fxn
+specific_order: 5
 ---
 
 Everlasting student · Zeitwerk · Rails Core · Fukuoka Ruby Award · Rails SaaS Conference Award · Ruby Hero Award · Freelance · Life lover

--- a/world/2024/speakers.html
+++ b/world/2024/speakers.html
@@ -6,9 +6,14 @@ title: Speakers
 ---
 
 {% assign sorted_speakers = site.world_speakers | where_exp: 'item', 'item.path contains "2024"' | sort: 'last_name' %}
-{% assign keynote_speakers = sorted_speakers | where: 'keynote', true %}
-{% assign non_keynote_speakers = sorted_speakers | where_exp: "speaker", "speaker.keynote != true" | sort: "first_name"
-%}
+
+{% assign specific_order_speakers = sorted_speakers | where_exp: 'item', 'item.specific_order != null' | sort: 'specific_order' %}
+
+{% assign remaining_speakers = sorted_speakers | where_exp: 'item', 'item.specific_order == null' %}
+
+{% assign keynote_speakers = remaining_speakers | where: 'keynote', true %}
+{% assign non_keynote_speakers = remaining_speakers | where_exp: "speaker", "speaker.keynote != true" | sort: "first_name" %}
+    
 
 <div class="speakersPageContainer">
 <div class="speakerSwooshContainer">
@@ -22,6 +27,17 @@ title: Speakers
     </div>
     <div class="bottomContainer">
         <div class="speakersContainer">
+            {% for speaker in specific_order_speakers %}
+            {%
+            include world/2024/speaker-card.html
+            first_name=speaker.first_name
+            last_name=speaker.last_name
+            role=speaker.role
+            company=speaker.company
+            photo=speaker.image_path
+            path=speaker.path
+            %}
+            {% endfor %}
             {% for speaker in keynote_speakers %}
             {%
             include world/2024/speaker-card.html


### PR DESCRIPTION
### Problem 
When speakers got released there where a few things that need to be tweaked. 

### Solution 
- Make the session box smaller on larger screens 
- Session text line-height + container padding touchups
- No stretching for session speaker images 
- Ability to specifically sort speakers 

<img width="1725" alt="SCR-20240528-kvzc" src="https://github.com/rails/website/assets/78773266/a5b84ebe-6950-4e8f-b401-e84cb0b45a02">
#### Sorted Speakers
<img width="1240" alt="SCR-20240528-kxxv" src="https://github.com/rails/website/assets/78773266/e7826adc-1988-4442-8232-47deaeee390d">


### Other Changes
Add back tito for the next batch release