### PR TITLE
Rails world

### DIFF
--- a/_layouts/world/2024/speaker.html
+++ b/_layouts/world/2024/speaker.html
@@ -71,7 +71,7 @@ layout: world/2024/default
                                     '/world/2024/{{ sessionUrl }}'
                                 )
                             ">
-                            <p class="sessionName">{{ session.title }} {{hasInfo}} </p>
+                            <p class="sessionName">{{ session.title }}</p>
                             {% if session.time %}
                             <div class="sessionTimeContainer">
                                 {% include world/2024/icons/clock.html %}

--- a/_world_speakers/2024/speakers/greg-molnar.md
+++ b/_world_speakers/2024/speakers/greg-molnar.md
@@ -4,7 +4,7 @@ first_name: Greg
 last_name: Molnar
 image_path: /assets/world/2024/images/speakers/g-molnar.jpg
 role: Information Security Consultant
-company: 
+company: Spektr Security
 keynote: false
 github: https://github.com/gregmolnar
 linkedin: https://www.linkedin.com/in/gregmolnar1/


### PR DESCRIPTION
@john-farina I assume that this hasInfo is there for debugging purposes? Having it there renders a "false" after the title of the talks.
![image](https://github.com/rails/website/assets/752058/e92a2319-d901-47e6-81a7-54774a55351d)

@AmandaPerino I added my company's name, because otherwise the card looks odd with nothing after the comma:

![image](https://github.com/rails/website/assets/752058/1bf7841a-9732-407b-a8fa-d97e89ed3a1d)
