### PR TITLE
Update Rails 7.1.3.4 release date to June 4, 2024

### DIFF
--- a/_data/version.yml
+++ b/_data/version.yml
@@ -1,3 +1,3 @@
 label: Rails 7.1.3.4
-date: May 17, 2024
+date: June 4, 2024
 url: /2024/6/4/Rails-Versions-6-1-7-8-7-0-8-4-and-7-1-3-4-have-been-released


### PR DESCRIPTION
This pull request updates the Rails 7.1.3.4 release date to June 4, 2024 as the following blog entry says.

* Rails Versions 6.1.7.8, 7.0.8.4, 7.1.3.4, and 7.2.0.beta2 have been released!
https://rubyonrails.org/2024/6/4/Rails-Versions-6-1-7-8-7-0-8-4-and-7-1-3-4-have-been-released