### PR TITLE
Remove Rails World 2024 talks from 2023 agenda

### DIFF
--- a/world/2023/agenda/day-0.html
+++ b/world/2023/agenda/day-0.html
@@ -5,6 +5,6 @@ day: day-0
 title: Agenda
 ---
 
-{% assign sessions = site.world_sessions | where_exp: "session", "session.path contains '/day-0/'" | sort: "running_order" %}
+{% assign sessions = site.world_sessions | where_exp: "session", "session.path contains '/2023/agenda/day-0/'" | sort: "running_order" %}
 
 {% include world/2023/agenda/items.html sessions=sessions %}

--- a/world/2023/agenda/day-1.html
+++ b/world/2023/agenda/day-1.html
@@ -5,6 +5,6 @@ day: day-1
 title: Agenda
 ---
 
-{% assign sessions = site.world_sessions | where_exp: "session", "session.path contains '/day-1/'" | sort: "running_order" %}
+{% assign sessions = site.world_sessions | where_exp: "session", "session.path contains '/2023/agenda/day-1/'" | sort: "running_order" %}
 
 {% include world/2023/agenda/items.html sessions=sessions %}

--- a/world/2023/agenda/day-2.html
+++ b/world/2023/agenda/day-2.html
@@ -5,6 +5,6 @@ day: day-2
 title: Agenda
 ---
 
-{% assign sessions = site.world_sessions | where_exp: "session", "session.path contains '/day-2/'" | sort: "running_order" %}
+{% assign sessions = site.world_sessions | where_exp: "session", "session.path contains '/2023/agenda/day-2/'" | sort: "running_order" %}
 
 {% include world/2023/agenda/items.html sessions=sessions %}


### PR DESCRIPTION
I noticed that the Rails World 2024 talks were leaking into the Rails World 2023 agenda. It seems like the 2023 agenda didn't scope the sessions to just the 2023 versions. This Pull Requests expands the filter to only match the 2023 sessions.

/cc @john-farina (since you added the 2024 agenda in https://github.com/rails/website/pull/312)

| **Before** |
| --- |
|  ![CleanShot 2024-08-10 at 11 06 43](https://github.com/user-attachments/assets/0d1bcb84-9604-42fa-bc24-7c8c76a8c17f) |

| **After** |
| --- |
|  ![CleanShot 2024-08-10 at 11 06 52](https://github.com/user-attachments/assets/e0d51953-2120-4b4d-b898-c8e10ec2edd4) |
