### PR TITLE
Fix day-2 running_order, Bruno

### DIFF
--- a/_world_sessions/2024/day-2/bruno-prieto.md
+++ b/_world_sessions/2024/day-2/bruno-prieto.md
@@ -4,7 +4,7 @@ title: Making accessible web apps with Rails and Hotwire
 speaker: bruno-prieto.md # name of md speaker file
 time: 13:45 - 14:15
 location: Track 1
-running_order: 6
+running_order: 8
 ---
 
 Nowadays, there is a lot of talk about accessibility, but is your web app accessible? In this session, I will share my perspective as a blind developer on how to build accessible web apps with real-world examples, beyond saying it's important and the need to use ARIA.


### PR DESCRIPTION
Bruno's talk is out of order:
![CleanShot 2024-09-05 at 18 14 23@2x](https://github.com/user-attachments/assets/dcf7338a-cd61-4767-a3a5-da62da137d35)

This is the order of `running_order`s:

0. [opening-session](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/1-opening-session.md)
1. [opening-keynote-eileen](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/opening-keynote-eileen.md)
2. [stephen-margheim](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/stephen-margheim.md)
3. [ridhwana-khan](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/ridhwana-khan.md)
4. [lunch-and-breaks](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/lunch-and-breaks.md)
5. [chris-power](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/chris-power.md)
6. [miles-mcguire](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/miles-mcguire.md)
7. [andrea-fomera](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/andrea-fomera.md)
8. [bruno-prieto](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/bruno-prieto.md)
  * this is currently `6`
9. [robby-russell](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/robby-russell.md)
  * this is currently `7`
10. xavier-noria[](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/xavier-noria.md)
  * this is currently `8`
11. julia-lopez[](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/julia-lopez.md)
  * this is currently `9`
12. obie-fernandez[](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/obie-fernandez.md)
  * this is currently `10`
13. david-henner[](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/david-henner.md)
  * this is currently `11`
14. closing-keynote-aaron[](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/closing-keynote-aaron.md)
  * this is currently `12`
15. closing-party[](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/closing-party.md)
  * this is currently `13`