### PR TITLE
Fix day-2 running_order, Obie

### DIFF
--- a/_world_sessions/2024/day-2/obie-fernandez.md
+++ b/_world_sessions/2024/day-2/obie-fernandez.md
@@ -4,7 +4,7 @@ title: Empowering the Individual - Rails on AI
 speaker: obie-fernandez.md # name of md speaker file
 time: 15:45 - 16:15
 location: Track 1
-running_order: 10
+running_order: 12
 ---
 
 The dream of the "One Person Framework" is more tangible than ever. Integrating AI with Ruby on Rails can transform a solo developer's workflow into an incredibly potent force, capable of competing at an unprecedented scale.


### PR DESCRIPTION
Follows upon #360 

This is the order of `running_order`s:

0. [opening-session](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/1-opening-session.md)
1. [opening-keynote-eileen](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/opening-keynote-eileen.md)
2. [stephen-margheim](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/stephen-margheim.md)
3. [ridhwana-khan](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/ridhwana-khan.md)
4. [lunch-and-breaks](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/lunch-and-breaks.md)
5. [chris-power](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/chris-power.md)
6. [miles-mcguire](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/miles-mcguire.md)
7. [andrea-fomera](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/andrea-fomera.md)
8. [bruno-prieto](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/bruno-prieto.md)
  * this is currently `6`
9. [robby-russell](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/robby-russell.md)
  * this is currently `7`
10. [xavier-noria](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/xavier-noria.md)
  * this is currently `8`
11. [julia-lopez](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/julia-lopez.md)
  * this is currently `9`
12. [obie-fernandez](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/obie-fernandez.md)
  * this is currently `10`
13. [david-henner](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/david-henner.md)
  * this is currently `11`
14. [closing-keynote-aaron](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/closing-keynote-aaron.md)
  * this is currently `12`
15. [closing-party](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/closing-party.md)
  * this is currently `13`