### PR TITLE
Update closing-party.md

### DIFF
--- a/_world_sessions/2024/day-2/closing-party.md
+++ b/_world_sessions/2024/day-2/closing-party.md
@@ -4,7 +4,7 @@ title: Shopify Closing Party
 speaker:
 time: 19:00 - 22:00
 location: Shopify Port
-running_order: 13
+running_order: 15
 ---
 
 Join us as we close out Rails World with a takeover at the Shopify Port. Three floors of music, games, food, drink, and fun, with plenty of space for pair programming if you have any code you need to tackle. Pre-registration will be required (attendees will be sent more details). Don't forget your badge!


### PR DESCRIPTION
Follows upon #363 

This is the order of `running_order`s:

0. [opening-session](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/1-opening-session.md)
1. [opening-keynote-eileen](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/opening-keynote-eileen.md)
2. [stephen-margheim](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/stephen-margheim.md)
3. [ridhwana-khan](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/ridhwana-khan.md)
4. [lunch-and-breaks](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/lunch-and-breaks.md)
5. [chris-power](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/chris-power.md)
6. [miles-mcguire](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/miles-mcguire.md)
7. [andrea-fomera](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/andrea-fomera.md)
8. [bruno-prieto](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/bruno-prieto.md)
  * this is currently `6`
9. [robby-russell](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/robby-russell.md)
  * this is currently `7`
10. [xavier-noria](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/xavier-noria.md)
  * this is currently `8`
11. [julia-lopez](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/julia-lopez.md)
  * this is currently `9`
12. [obie-fernandez](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/obie-fernandez.md)
  * this is currently `10`
13. [david-henner](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/david-henner.md)
  * this is currently `11`
14. [closing-keynote-aaron](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/closing-keynote-aaron.md)
  * this is currently `12`
15. [closing-party](https://github.com/rails/website/blob/main/_world_sessions/2024/day-2/closing-party.md)
  * this is currently `13`