### PR TITLE
Rails World 2024: Speaker spacing issue in session card

### DIFF
--- a/_includes/world/2024/agenda-page.html
+++ b/_includes/world/2024/agenda-page.html
@@ -23,7 +23,9 @@
 <div class="dayContainer">
   <div class="titleContainer">
     <h2>Agenda</h2>
-    <p>Rails World is two full days of keynotes, technical sessions, workshops, food, and fun. The Rails World app is being developed by Telos Labs and will be released soon so that attendees can build their schedule. All sessions on the two
+    <p>Rails World is two full days of keynotes, technical sessions, workshops, food, and fun. The Rails World app is
+      being developed by Telos Labs and will be released soon so that attendees can build their schedule. All sessions
+      on the two
       main stages will be recorded and will be shared shortly after the event.</p>
   </div>
   <div class="mainContainer">
@@ -58,34 +60,88 @@
           <div class="separator"></div>
         </div>
         <div class="right">
-          {% assign speakerId = session.speaker | split: '/' | last %}
-          {% assign speakerObjs = site.world_speakers | where_exp:"speaker", "speaker.path contains speakerId" |
-          where_exp: 'item', 'item.path contains "2024"' %}
-          {% assign primarySpeaker = speakerObjs | first %}
+          {% assign primarySpeakerId = session.speaker | split: '/' | last %}
           {% assign secondSpeakerId = session.second_speaker | split: '/' | last %}
           {% assign thirdSpeakerId = session.third_speaker | split: '/' | last %}
-          {% assign secondSpeakerObjs = site.world_speakers | where_exp:"speaker", "speaker.path contains
+
+          {% assign primarySpeakerObjs = site.world_speakers | where_exp: "speaker", "speaker.path contains
+          primarySpeakerId" | where_exp: 'item', 'item.path contains "2024"' %}
+          {% assign secondarySpeakerObjs = site.world_speakers | where_exp: "speaker", "speaker.path contains
           secondSpeakerId" | where_exp: 'item', 'item.path contains "2024"' %}
-          {% assign secondarySpeaker = secondSpeakerObjs | first %}
-          {% assign thirdSpeakerObjs = site.world_speakers | where_exp:"speaker", "speaker.path contains
+          {% assign thirdSpeakerObjs = site.world_speakers | where_exp: "speaker", "speaker.path contains
           thirdSpeakerId" | where_exp: 'item', 'item.path contains "2024"' %}
+
+          {% assign primarySpeaker = primarySpeakerObjs | first %}
+          {% assign secondarySpeaker = secondarySpeakerObjs | first %}
           {% assign thirdSpeaker = thirdSpeakerObjs | first %}
 
+          {% assign speakerIds =
+          session.speaker | split: '/' | last | append: "," |
+          append: session.second_speaker | split: '/' | last | append: "," |
+          append: session.third_speaker | split: '/' | last | split: "," %}
+
+          {% assign speakers = "" %}
+          {% for id in speakerIds %}
+          {% assign speakerObjs = site.world_speakers | where_exp: "speaker", "speaker.path contains id" | where_exp:
+          'item', 'item.path contains "2024"' %}
+          {% assign speaker = speakerObjs | first %}
+          {% if speaker %}
+          {% assign speakers = speakers | append: speaker.first_name | append: " " | append: speaker.last_name | append:
+          "," | append: speaker.role | append: "," | append: speaker.company | append: "|" %}
+          {% endif %}
+          {% endfor %}
+
+          {% assign speakerArray = speakers | split: "|" %}
+          {% assign totalSpeakers = speakerArray | size %}
+          {% assign speakerList = "" %}
+
           <p class="title">{{ session.title }}</p>
-          <div class="speakersContainer">
-            {% if primarySpeaker %}
-            <p class="speakerName">{{ primarySpeaker.first_name }} {{ primarySpeaker.last_name }}, {{
-              primarySpeaker.role }}{% if primarySpeaker.company %}, {{ primarySpeaker.company }}{% endif %}</p>
-            {% endif %}
-            {% if secondarySpeaker %}
-            <p class="speakerName">, {{ secondarySpeaker.first_name }} {{ secondarySpeaker.last_name }}, {{
-              secondarySpeaker.role }}{% if secondarySpeaker.company %}, {{ secondarySpeaker.company }}{% endif %}</p>
-            {% endif %}
-            {% if thirdSpeaker %}
-            <p class="speakerName">, {{ thirdSpeaker.first_name }} {{ thirdSpeaker.last_name }}, {{
-              thirdSpeaker.role }}{% if thirdSpeaker.company %}, {{ thirdSpeaker.company }}{% endif %}</p>
-            {% endif %}
-          </div>
+          {% if totalSpeakers > 0 %}
+            <div class="speakersContainer">
+              <p class="speakerNames">
+                {% assign speakerList = "" %}
+                {% assign firstSpeaker = true %}
+                {% assign lastIndex = totalSpeakers | minus: 1 %}
+
+                {% for speaker in speakerArray %}
+                  {% if speaker != "" %}
+                    {% assign speakerDetails = speaker | split: "," %}
+                
+                    {% unless firstSpeaker %}
+                      {% assign speakerList = speakerList | append: ", " %}
+                    {% endunless %}
+                    
+                    {% if forloop.index0 == lastIndex %}
+                      {% if totalSpeakers > 1 %}
+                        {% assign speakerList = speakerList | append: " & " %}
+                      {% endif %}
+                    {% endif %}
+                
+                    {% assign firstSpeaker = false %}
+
+                    {% assign speakerList = speakerList | append: "<span class='name'>" | append: speakerDetails[0] | append: "</span>" %}
+                
+                    {% if speakerDetails[1] != "" %}
+                      {% assign speakerList = speakerList | append: " " | append: speakerDetails[1] %}
+                    {% endif %}
+                
+                    {% if speakerDetails[2] != "" %}
+                      {% if speakerDetails[1] != "" %}
+                        {% assign speakerList = speakerList %}
+                      {% endif %}
+                      {% if speakerDetails[1] == "" %}
+                        {% assign speakerList = speakerList | append: " " %}
+                      {% endif %}
+                      
+                      {% assign speakerList = speakerList | append: speakerDetails[2] %}
+                    {% endif %}
+                  {% endif %}
+                {% endfor %}
+
+                {{ speakerList | raw }}
+              </p>
+            </div>
+          {% endif %}
         </div>
       </div>
       {% endfor %}

--- a/_includes/world/2024/agenda-page.html
+++ b/_includes/world/2024/agenda-page.html
@@ -23,10 +23,7 @@
 <div class="dayContainer">
   <div class="titleContainer">
     <h2>Agenda</h2>
-    <p>Rails World is two full days of keynotes, technical sessions, workshops, food, and fun. The Rails World app is
-      being developed by Telos Labs and will be released soon so that attendees can build their schedule. All sessions
-      on the two
-      main stages will be recorded and will be shared shortly after the event.</p>
+    <p>Rails World is two full days of keynotes, technical sessions, workshops, food, and fun. The Rails World app is being developed by Telos Labs and will be released soon so that attendees can build their schedule. All sessions on the two</p>
   </div>
   <div class="mainContainer">
     <div class="dayTabs">
@@ -60,21 +57,6 @@
           <div class="separator"></div>
         </div>
         <div class="right">
-          {% assign primarySpeakerId = session.speaker | split: '/' | last %}
-          {% assign secondSpeakerId = session.second_speaker | split: '/' | last %}
-          {% assign thirdSpeakerId = session.third_speaker | split: '/' | last %}
-
-          {% assign primarySpeakerObjs = site.world_speakers | where_exp: "speaker", "speaker.path contains
-          primarySpeakerId" | where_exp: 'item', 'item.path contains "2024"' %}
-          {% assign secondarySpeakerObjs = site.world_speakers | where_exp: "speaker", "speaker.path contains
-          secondSpeakerId" | where_exp: 'item', 'item.path contains "2024"' %}
-          {% assign thirdSpeakerObjs = site.world_speakers | where_exp: "speaker", "speaker.path contains
-          thirdSpeakerId" | where_exp: 'item', 'item.path contains "2024"' %}
-
-          {% assign primarySpeaker = primarySpeakerObjs | first %}
-          {% assign secondarySpeaker = secondarySpeakerObjs | first %}
-          {% assign thirdSpeaker = thirdSpeakerObjs | first %}
-
           {% assign speakerIds =
           session.speaker | split: '/' | last | append: "," |
           append: session.second_speaker | split: '/' | last | append: "," |

--- a/_includes/world/2024/agenda-page.html
+++ b/_includes/world/2024/agenda-page.html
@@ -90,30 +90,27 @@
                     {% assign speakerDetails = speaker | split: "," %}
                 
                     {% unless firstSpeaker %}
-                      {% assign speakerList = speakerList | append: ", " %}
+                      {% assign speakerList = speakerList | append: " - " %}
                     {% endunless %}
                     
-                    {% if forloop.index0 == lastIndex %}
-                      {% if totalSpeakers > 1 %}
-                        {% assign speakerList = speakerList | append: " & " %}
-                      {% endif %}
-                    {% endif %}
+                 
                 
                     {% assign firstSpeaker = false %}
 
-                    {% assign speakerList = speakerList | append: "<span class='name'>" | append: speakerDetails[0] | append: "</span>" %}
+                    {% assign speakerList = speakerList | append: "<span class='name'>" | append: speakerDetails[0] | append: "</span>" | append: "," %}
                 
                     {% if speakerDetails[1] != "" %}
                       {% assign speakerList = speakerList | append: " " | append: speakerDetails[1] %}
                     {% endif %}
-                
-                    {% if speakerDetails[2] != "" %}
-                      {% if speakerDetails[1] != "" %}
-                        {% assign speakerList = speakerList %}
-                      {% endif %}
-                      {% if speakerDetails[1] == "" %}
-                        {% assign speakerList = speakerList | append: " " %}
-                      {% endif %}
+
+                    {% if speakerDetails[2] == "" or speakerDetails[2] == "false" %}
+                      {% assign speakerList = speakerList | append: "" %}
+                    {% else %}
+                      {% assign speakerList = speakerList | append: ", " %}
+                    {% endif %}
+
+                    {% if speakerDetails[2] != "" and speakerDetails[2] != "false" %}
+                      {% assign speakerList = speakerList %}
                       
                       {% assign speakerList = speakerList | append: speakerDetails[2] %}
                     {% endif %}

--- a/_includes/world/2024/speaker-card.html
+++ b/_includes/world/2024/speaker-card.html
@@ -33,8 +33,9 @@
             <h4 class="name">
                 {{ include.first_name }} {{ include.last_name }}
             </h4>
-
-            <p class="role">{{ include.role }}, {{ include.company }}</p>
+            <p>
+                {{ include.role }}{% if include.company and include.company != "false" %}, {{ include.company }}{% endif %}
+            </p>
         </div>
     </div>
 </div>

--- a/_layouts/world/2024/speaker.html
+++ b/_layouts/world/2024/speaker.html
@@ -23,7 +23,7 @@ layout: world/2024/default
                 <div class="right">
                     <div>
                         <h2 class="speakerName">{{ page.first_name}} {{ page.last_name }}</h1>
-                            <p class="speakerRole">{{ page.role }}, {{ page.company }}</p>
+                            <p class="speakerRole">{{ page.role }}{% if include.company and include.company != "false" %}, {{ include.company }}{% endif %}</p>
                     </div>
                     {{ content }}
 

--- a/_sass/world/2024/modules/_agenda.scss
+++ b/_sass/world/2024/modules/_agenda.scss
@@ -29,6 +29,7 @@
   max-width: 1300px;
   align-items: center;
   justify-content: center;
+
 }
 
 @media screen and (max-width: 900px) {
@@ -96,9 +97,8 @@
   display: flex;
   flex-direction: column;
   background-color: var(--white);
-  border-radius: 0 0px 10px 10px;
+  border-radius: 0 0 10px 10px;
   width: 100%;
-  padding-bottom: 10px;
 }
 
 .sessionRow {
@@ -138,23 +138,34 @@
 
     .title {
       font-weight: 600;
+
       color: var(--purple);
     }
 
     .speakersContainer {
       display: flex;
 
-      .speakerName {
+      .speakerNames {
         font-size: var(--type-small);
+
+        .name {
+          font-weight: 500;
+        }
       }
     }
   }
+
+  &:last-child {
+    border-bottom: none;
+    border-radius: 0 0 10px 10px;
+  }
+
+  &:hover {
+    background-color: rgb(242, 242, 242);
+  }
+
+  @media screen and (max-width: 650px) {
+    padding: 5px 0;
+  }
 }
 
-.sessionRow:last-child {
-  border-bottom: none;
-}
-
-.sessionRow:hover {
-  background-color: rgb(242, 242, 242);
-}

--- a/_world_speakers/2024/speakers/yukihiro-matz.md
+++ b/_world_speakers/2024/speakers/yukihiro-matz.md
@@ -4,7 +4,7 @@ first_name: Yukihiro "Matz"
 last_name: Matsumoto
 image_path: /assets/world/2024/images/speakers/m-matsumoto.jpg
 role: Creator of Ruby
-company: 
+company: false
 keynote: true
 github: https://github.com/matz
 linkedin:  


### PR DESCRIPTION
### Problem
The main issue was - when there were more than two speakers it messed with the spacing
<img width="1063" alt="Screenshot 2024-09-09 at 20 08 50" src="https://github.com/user-attachments/assets/0f6aebc4-fa3f-4c5a-883a-128ffb5f33a1">

### Solution 
Merge them all into one `<p>` tag so it will wrap like a normal sentence 
<img width="1012" alt="SCR-20240909-sepr" src="https://github.com/user-attachments/assets/27edfa07-d3d5-4751-b53b-d51df5d3d863">


#### Other changes
##### Read-ability
- Put "-" in between speakers for clarity
- I made the speaker names bold since I had a hard time reading it from a far

##### Small Bugs
- the bottom padding of the agenda pages spacing was a bit off, so I fixed that (no more spacing at the bottom)
- increased padding for mobile agenda cards (so the text doesn't touch the top) 
<img width="320" alt="SCR-20240909-sezg" src="https://github.com/user-attachments/assets/cda51ba6-3b03-403d-bb05-0da9107f10ab">

