### PR TITLE
Rails World 2024: Speaker cards role & company text bug

### DIFF
--- a/_includes/world/2024/speaker-card.html
+++ b/_includes/world/2024/speaker-card.html
@@ -33,7 +33,7 @@
             <h4 class="name">
                 {{ include.first_name }} {{ include.last_name }}
             </h4>
-            <p>
+            <p class="roleAndCompany">
                 {{ include.role }}{% if include.company and include.company != "false" %}, {{ include.company }}{% endif %}
             </p>
         </div>

--- a/_sass/world/2024/modules/_speaker_card.scss
+++ b/_sass/world/2024/modules/_speaker_card.scss
@@ -96,12 +96,11 @@
                 font-weight: 500;
             }
 
-            .role {
-                // text-transform: uppercase;
+            .roleAndCompany {
                 font-weight: 300;
                 word-spacing: 1px;
                 line-height: 0.9;
-                font-size: 1.23rem;
+                font-size: 1.53rem;
                 text-align: center;
             }
         }


### PR DESCRIPTION
### Problem 
The role and company text in the speaker card were too big 
<img width="1281" alt="Screenshot 2024-09-11 at 20 13 36" src="https://github.com/user-attachments/assets/0192d2b8-8a69-4f88-8642-16e6d73eb405">

### Solution 
Update class so it properly gets styled

<img width="252" alt="SCR-20240911-odxe" src="https://github.com/user-attachments/assets/d211ef76-b6dc-4dd4-a6a1-b4c3cfc6effa">
