### PR TITLE
Add note for security support for 6.1.x until Jan 1, 2025

### DIFF
--- a/_pages/maintenance.html
+++ b/_pages/maintenance.html
@@ -48,7 +48,7 @@ redirect_from:
           <li><strong>7.2.x</strong> - Supported until August 9, 2026</li>
           <li><strong>7.1.x</strong> - Supported until October 1, 2025</li>
           <li><strong>7.0.x</strong> - Supported until April 1, 2025</li>
-          <li><strong>6.1.x</strong> - Supported until October 1, 2024</li>
+          <li><strong>6.1.x</strong> - Supported until January 1, 2025</li>
         </ul>
         <h3 id="unsupported">Unsupported Release Series</h3>
         <p>When a release series is no longer supported, it’s your own responsibility to deal with bugs and security issues. We may provide backports of the fixes and publish them to git, however there will be no new versions released. If you are not comfortable maintaining your own versions, you should upgrade to a supported version.</p>


### PR DESCRIPTION
Respecfully request official change to maintenance policy for security updates until January 1, 2025 for Rails 6.1.x based on [this discussion](https://github.com/rails/rails/pull/52471) and [specifically this comment](https://github.com/rails/rails/pull/52471#issuecomment-2364190880)

Some background and justification for this request:
 - Rails created an official maintenance policy [in August](https://github.com/rails/rails/pull/52471) that sets definite dates for security and maintenance periods.  This is excellent and allows us to ensure these updates are competed on time
 - Based on the previous policy, our team thought that we had maintenance until mid next year so have several apps that still need to be updated to the latest version of rails
 - We will have all of these done by the end up the year
 - I am willing to personally help here to backport any security issues, I echo Rafael in that it is unlikely