### PR TITLE
Fix link to latest version in the home page

### DIFF
--- a/_posts/2024-10-30-Rails-Versions-7-2-2-and-7-1-5-have-been-released.md
+++ b/_posts/2024-10-30-Rails-Versions-7-2-2-and-7-1-5-have-been-released.md
@@ -4,7 +4,7 @@ title: 'Rails Versions 7.1.5 and 7.2.2 have been released!'
 categories: releases
 author: jhawthorn
 published: true
-date: 2024-10-30 18:40:00 -07:00
+date: 2024-10-30 18:40:00
 ---
 
 Hi friends!


### PR DESCRIPTION
The home page's link to the latest release is 404ing, even though the post exists. The release post's date is October 30th, but in production, the post is being listed as October 31st.

This is likely a time zone issue. The post's date in the markdown file is October 30th 18:40 -07:00, which is October 31st in UTC.

In the future, we should probably refrain from adding time zones.