### PR TITLE
Add rails 8.0 to maintenance page

### DIFF
--- a/_pages/maintenance.html
+++ b/_pages/maintenance.html
@@ -32,8 +32,8 @@ redirect_from:
           unsupported.</p>
         <h6>List of currently supported releases</h6>
         <ul>
+          <li><strong>8.0.x</strong> - Supported until November 7, 2025</li>
           <li><strong>7.2.x</strong> - Supported until August 9, 2025</li>
-          </li>
         </ul>
         <h3 id="security">Security Issues</h3>
         <p>
@@ -44,6 +44,7 @@ redirect_from:
         </p>
         <h6>List of currently supported releases</h6>
         <ul>
+          <li><strong>8.0.x</strong> - Supported until November 7, 2026</li>
           <li><strong>7.2.x</strong> - Supported until August 9, 2026</li>
           <li><strong>7.1.x</strong> - Supported until October 1, 2025</li>
           <li><strong>7.0.x</strong> - Supported until April 1, 2025</li>


### PR DESCRIPTION
Added the 8.0 release to both bugfix and security section with what I believe are correct dates.

Removed what I think is an erroneous stray `</li>` while in there.

If anyone reviews this and has thoughts on related questions in https://github.com/rails/website/issues/387 I'd appreciate any feedback there.