### PR TITLE
Add a Foundation blog category

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ world24_title: Rails World - 2024
 plugins:
   - jekyll-feed
   - jekyll-paginate
-  # - jekyll-redirect-from
+  - jekyll-redirect-from
   - jekyll-sitemap
   - jemoji
 

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ world24_title: Rails World - 2024
 plugins:
   - jekyll-feed
   - jekyll-paginate
-  - jekyll-redirect-from
+  # - jekyll-redirect-from
   - jekyll-sitemap
   - jemoji
 

--- a/_pages/foundation.html
+++ b/_pages/foundation.html
@@ -151,7 +151,7 @@ redirect_from:
         <p>The foundation is always open to new Contributing members. Please apply for membership by writing to <a href="mailto:foundation@rubyonrails.org">foundation@rubyonrails.org</a> for more details. If your company has been benefiting from Rails over the years, but not sure how it might give back to the ecosystem, now there's a clear and obvious choice.</p>
         
         <div class="container">
-          <a href="https://public.3.basecamp.com/p/7ymKZrwbdPoZhwCzhH2SZkLH/upload/download/Rails%20Foundation%20Membership%20Deck%20Nov%202024.pdf?disposition=attachment" class="common-button common-button--size-medium common-button--color-red" style="color: #FFF"><span>Download the membership deck</span></a>
+          <a href="https://public.3.basecamp.com/p/7ymKZrwbdPoZhwCzhH2SZkLH" class="common-button common-button--size-medium common-button--color-red" style="color: #FFF"><span>Download the membership deck</span></a>
         </div>
 
 

--- a/_pages/foundation.html
+++ b/_pages/foundation.html
@@ -149,6 +149,12 @@ redirect_from:
         </div>
 
         <p>The foundation is always open to new Contributing members. Please apply for membership by writing to <a href="mailto:foundation@rubyonrails.org">foundation@rubyonrails.org</a> for more details. If your company has been benefiting from Rails over the years, but not sure how it might give back to the ecosystem, now there's a clear and obvious choice.</p>
+        
+        <div class="container">
+          <a href="" class="common-button common-button--size-medium common-button--color-red" style="color: #FFF"><span>Download the membership deck</span></a>
+        </div>
+
+
         <hr class="divider" />
 
         <h3>Our Board.</h3>
@@ -193,25 +199,6 @@ redirect_from:
 
         <hr class="divider" />
         <p><a href="/privacy">Rails Foundation Privacy Policy</a>
-      </div>
-      <div class="heading common-padding--bottom common-padding--top">
-        <div class="container">
-          <div class="heading__body">
-            <div class="heading__headline common-headline">
-              <h2>You can make it better.</h2>
-      
-              <h4>Not only is Rails free to use, you can also help make it better. <a href="http://contributors.rubyonrails.org">More than 6,000 people</a> have already contributed.</h4>
-            </div>
-      
-            <div class="heading__button">
-              <a href="https://discord.gg/d8N68BCw49" class="common-button common-button--text common-button--icon-arrow"><span>Discuss your contributions with the team</span></a>
-            </div>
-      
-            <div class="heading__button">
-              <a href="https://github.com/rails/rails" class="common-button common-button--size-medium common-button--color-red"><span>Contribute on GitHub</span></a>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
   </div>

--- a/_pages/foundation.html
+++ b/_pages/foundation.html
@@ -150,7 +150,7 @@ redirect_from:
 
         <p>The foundation is always open to new Contributing members. Please apply for membership by writing to <a href="mailto:foundation@rubyonrails.org">foundation@rubyonrails.org</a> for more details. If your company has been benefiting from Rails over the years, but not sure how it might give back to the ecosystem, now there's a clear and obvious choice.</p>
         
-        <div class="container">
+        <div class="container" style="display: flex; justify-content: center; padding: 20px">
           <a href="https://public.3.basecamp.com/p/7ymKZrwbdPoZhwCzhH2SZkLH" class="common-button common-button--size-medium common-button--color-red" style="color: #FFF"><span>Download the membership deck</span></a>
         </div>
 

--- a/_pages/foundation.html
+++ b/_pages/foundation.html
@@ -33,22 +33,20 @@ redirect_from:
         <p>We will also be administering <a href="/trademarks">the Rails trademarks</a> through an exclusive license from the trademark owner.</p>
         <p>Here are some of our recent announcements:</p>
         
-        
-        <div class="container">
-          
+        <ul style="padding-left: 0;">
           {% assign sorted_posts = site.categories[page.category] | sort: 'date' | reverse %}
           {% assign limited_posts = sorted_posts | slice: 0, 8 %}
           {% for post in limited_posts %}
-            <p style="font-size: 18px; color: #5A5153; font-weight: 400">
-              <span>
-                {{ post.date | date: '%b %-d, %Y' }} -
-              </span>
-              <a href="{{ post.url }}">{{ post.title | strip_html }}</a>
-            </p>
+            <li style="display: flex; gap: 2rem; margin-top: 1rem;">
+              <div style="white-space: nowrap; flex-shrink: 0; width: 6rem;">
+                {{ post.date | date: '%b %-d, %Y' }}
+              </div>
+              <div>
+                <a href="{{ post.url }}">{{ post.title | strip_html }}</a>
+              </div>
+            </li>
           {% endfor %}
-          
-      
-        </div>
+        </ul>
 
         <hr class="divider" />
 

--- a/_pages/foundation.html
+++ b/_pages/foundation.html
@@ -31,19 +31,20 @@ redirect_from:
         <p>The foundation will commission freelancers and firms to work on better written documentation, more compelling screencasts, exciting events, and much more. We've only just gotten started, so more detailed plans are still to follow.</p>
 
         <p>We will also be administering <a href="/trademarks">the Rails trademarks</a> through an exclusive license from the trademark owner.</p>
+        <p>Here are some of our recent announcements:</p>
         
-        <hr class="divider" />
-
-        <h3>Our Posts.</h3>
+        
         <div class="container">
           
           {% assign sorted_posts = site.categories[page.category] | sort: 'date' | reverse %}
           {% assign limited_posts = sorted_posts | slice: 0, 8 %}
           {% for post in limited_posts %}
-            <h6 style="font-size: 21px; color: #5A5153; font-weight: 400">
-              {{ post.date | date: '%b %-d, %Y' }} - 
+            <p style="font-size: 18px; color: #5A5153; font-weight: 400">
+              <span>
+                {{ post.date | date: '%b %-d, %Y' }} -
+              </span>
               <a href="{{ post.url }}">{{ post.title | strip_html }}</a>
-            </h6>
+            </p>
           {% endfor %}
           
       

--- a/_pages/foundation.html
+++ b/_pages/foundation.html
@@ -1,6 +1,7 @@
 ---
 title: The Rails Foundation
 description:
+category: foundation
 permalink: /foundation
 redirect_from:
   - /foundation/
@@ -30,6 +31,21 @@ redirect_from:
         <p>The foundation will commission freelancers and firms to work on better written documentation, more compelling screencasts, exciting events, and much more. We've only just gotten started, so more detailed plans are still to follow.</p>
 
         <p>We will also be administering <a href="/trademarks">the Rails trademarks</a> through an exclusive license from the trademark owner.</p>
+        
+        <hr class="divider" />
+
+        <h3>Our Posts.</h3>
+        <div class="container">
+          
+            {% for post in site.categories[page.category] %}
+            <h6 style="font-size: 21px; color: #5A5153; font-weight: 400">
+              {{ post.date | date: '%b %-d, %Y' }} - 
+              <a href="{{ post.url }}">{{ post.title | strip_html }}</a>
+            </h6>
+            {% endfor %}
+          
+      
+        </div>
 
         <hr class="divider" />
 
@@ -174,6 +190,25 @@ redirect_from:
 
         <hr class="divider" />
         <p><a href="/privacy">Rails Foundation Privacy Policy</a>
+      </div>
+      <div class="heading common-padding--bottom common-padding--top">
+        <div class="container">
+          <div class="heading__body">
+            <div class="heading__headline common-headline">
+              <h2>You can make it better.</h2>
+      
+              <h4>Not only is Rails free to use, you can also help make it better. <a href="http://contributors.rubyonrails.org">More than 6,000 people</a> have already contributed.</h4>
+            </div>
+      
+            <div class="heading__button">
+              <a href="https://discord.gg/d8N68BCw49" class="common-button common-button--text common-button--icon-arrow"><span>Discuss your contributions with the team</span></a>
+            </div>
+      
+            <div class="heading__button">
+              <a href="https://github.com/rails/rails" class="common-button common-button--size-large common-button--color-red"><span>Contribute on GitHub</span></a>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/_pages/foundation.html
+++ b/_pages/foundation.html
@@ -37,12 +37,14 @@ redirect_from:
         <h3>Our Posts.</h3>
         <div class="container">
           
-            {% for post in site.categories[page.category] %}
+          {% assign sorted_posts = site.categories[page.category] | sort: 'date' | reverse %}
+          {% assign limited_posts = sorted_posts | slice: 0, 8 %}
+          {% for post in limited_posts %}
             <h6 style="font-size: 21px; color: #5A5153; font-weight: 400">
               {{ post.date | date: '%b %-d, %Y' }} - 
               <a href="{{ post.url }}">{{ post.title | strip_html }}</a>
             </h6>
-            {% endfor %}
+          {% endfor %}
           
       
         </div>

--- a/_pages/foundation.html
+++ b/_pages/foundation.html
@@ -207,7 +207,7 @@ redirect_from:
             </div>
       
             <div class="heading__button">
-              <a href="https://github.com/rails/rails" class="common-button common-button--size-large common-button--color-red"><span>Contribute on GitHub</span></a>
+              <a href="https://github.com/rails/rails" class="common-button common-button--size-medium common-button--color-red"><span>Contribute on GitHub</span></a>
             </div>
           </div>
         </div>

--- a/_pages/foundation.html
+++ b/_pages/foundation.html
@@ -151,7 +151,7 @@ redirect_from:
         <p>The foundation is always open to new Contributing members. Please apply for membership by writing to <a href="mailto:foundation@rubyonrails.org">foundation@rubyonrails.org</a> for more details. If your company has been benefiting from Rails over the years, but not sure how it might give back to the ecosystem, now there's a clear and obvious choice.</p>
         
         <div class="container">
-          <a href="" class="common-button common-button--size-medium common-button--color-red" style="color: #FFF"><span>Download the membership deck</span></a>
+          <a href="https://public.3.basecamp.com/p/7ymKZrwbdPoZhwCzhH2SZkLH/upload/download/Rails%20Foundation%20Membership%20Deck%20Nov%202024.pdf?disposition=attachment" class="common-button common-button--size-medium common-button--color-red" style="color: #FFF"><span>Download the membership deck</span></a>
         </div>
 
 

--- a/_posts/2024-08-02-nominations-open-for-2024-luminaries.markdown
+++ b/_posts/2024-08-02-nominations-open-for-2024-luminaries.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Nominations open for the 2024 Rails Luminary Awards"
-categories: news
+categories: news, foundation
 author: Amanda Perino
 published: true
 date: 2024-08-02

--- a/_posts/2024-08-02-this-week-in-rails.markdown
+++ b/_posts/2024-08-02-this-week-in-rails.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Rails Luminary nominations open, new maintenance policy and more!"
-categories: news
+categories: news, foundation
 author: Greg
 og_image: assets/images/this-week-in-rails.png
 published: true

--- a/_posts/2024-08-02-this-week-in-rails.markdown
+++ b/_posts/2024-08-02-this-week-in-rails.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Rails Luminary nominations open, new maintenance policy and more!"
-categories: news, foundation
+categories: news
 author: Greg
 og_image: assets/images/this-week-in-rails.png
 published: true

--- a/_posts/2024-08-07-matz-and-dhh-fireside-chat.markdown
+++ b/_posts/2024-08-07-matz-and-dhh-fireside-chat.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Special Rails World session: Matz & DHH Fireside Chat"
-categories: news
+categories: news, foundation
 author: Rails Foundation
 published: true
 date: 2024-08-07

--- a/_posts/2024-08-27-appsignal-returns-as-platinum-rails-world-sponsor.markdown
+++ b/_posts/2024-08-27-appsignal-returns-as-platinum-rails-world-sponsor.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "AppSignal returns as a Platinum Sponsor at this year’s Rails World"
-categories: news
+categories: news, foundation
 author: The Rails Foundation
 published: true
 date: 2024-08-27

--- a/_posts/2024-08-30-shopify-as-rails-world-toronto-city-host.markdown
+++ b/_posts/2024-08-30-shopify-as-rails-world-toronto-city-host.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Shopify is the official Toronto City Host for Rails World 2024"
-categories: news
+categories: news, foundation
 author: The Rails Foundation
 published: true
 date: 2024-08-30

--- a/_posts/2024-09-04-github-joins-rails-world-as-platinum-sponsor.markdown
+++ b/_posts/2024-09-04-github-joins-rails-world-as-platinum-sponsor.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "GitHub joins Rails World 2024 as Platinum Sponsor and Track 1 Host"
-categories: news
+categories: news, foundation
 author: The Rails Foundation
 published: true
 date: 2024-09-05

--- a/_posts/2024-09-27-2024-rails-luminary-awards-matz-and-akira.markdown
+++ b/_posts/2024-09-27-2024-rails-luminary-awards-matz-and-akira.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Announcing the 2024 Rails Luminary Winners: Akira Matsuda & Yukihiro Matsumoto"
-categories: news
+categories: news, foundation
 author: The Rails Foundation
 published: true
 date: 2024-09-27

--- a/_posts/2024-11-12-rails-world-videos-localized-and-reedited.markdown
+++ b/_posts/2024-11-12-rails-world-videos-localized-and-reedited.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Rails World 2024 videos re-edited and localized in 3 languages"
-categories: news
+categories: news, foundation
 author: Amanda Perino
 published: true
 date: 2024-11-12

--- a/_posts/2024-12-02-rails-foundation-welcomes-1password-as-core-member.markdown
+++ b/_posts/2024-12-02-rails-foundation-welcomes-1password-as-core-member.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "The Rails Foundation welcomes 1Password as Core member"
-categories: news
+categories: news, foundation
 author: The Rails Foundation
 published: true
 date: 2024-12-02

--- a/_posts/2025-11-27-rails-world-2025-save-the-date.markdown
+++ b/_posts/2025-11-27-rails-world-2025-save-the-date.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Rails World 2025: Save the date - September 4 & 5, Amsterdam"
-categories: news
+categories: news, foundation
 author: The Rails Foundation
 published: true
 date: 2024-11-27

--- a/blog/index.html
+++ b/blog/index.html
@@ -12,6 +12,7 @@ description:
             <li><a href="/blog"><span>Everything</span></a></li>
             <li><a href="/category/releases"><span>Releases</span></a></li>
             <li><a href="/category/news"><span>News</span></a></li>
+            <li><a href="/category/foundation"><span>Foundation</span></a></li>
           </ul>
         </div>
       </div>

--- a/category/foundation.html
+++ b/category/foundation.html
@@ -1,0 +1,32 @@
+---
+title: Foundation
+description:
+category: foundation
+permalink: /category/foundation
+redirect_from:
+  - /category/foundation/
+---
+
+<div class="heading common-padding--bottom-small common-padding--top-small">
+  <div class="container">
+    <div class="heading__body">
+      <div class="heading__headline common-headline">
+        <h1>{{ page.title }}</h1>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="blog common-padding--bottom">
+  <div class="container">
+    <div class="blog__posts">
+
+{% for post in site.categories[page.category] %}
+
+    {% include post.html %}
+
+{% endfor %}
+
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This PR adds a "Foundation" category for blog posts, updates the index page to show this category on the top, and implements a short list on the Foundation page, with the most recent blog posts within this category. It also adds a prospectus button, with temporary copy around it, to the bottom of the Foundation page.

I tagged 9 posts with the Foundation category to verify that the short list is showing only the most recent 8 posts.

Besides the unfinished copy and layout adjustments, this also needs @AmandaPerino's review and approval before it can be merged.