### PR TITLE
Update security policy

### DIFF
--- a/_pages/security.html
+++ b/_pages/security.html
@@ -28,9 +28,9 @@ redirect_from:
         <p>Please see the <a href="https://guides.rubyonrails.org/maintenance_policy.html#security-issues">Maintenance policy</a> for supported versions.</p>
         <hr class="divider" />
         <h3>Reporting a Vulnerability</h3>
-        <p>All security bugs in Rails should be reported through our <a href="https://hackerone.com/rails">bounty program page at HackerOne</a>. This will deliver a message to a subset of the core team who handle security issues. Your report will be acknowledged within 24 hours, and you’ll receive a more detailed response to your email within 48 hours indicating the next steps in handling your report.</p>
-        <p>After the initial reply to your report the security team will endeavor to keep you informed of the progress being made towards a fix and full announcement. These updates will be sent at least every five days, in reality this is more likely to be every 24-48 hours.</p>
-        <p>If you have not received a reply to your email within 48 hours, or have not heard from the security team for the past five days there are a few steps you can take:</p>
+        <p>All security bugs in Rails should be reported through our <a href="https://hackerone.com/rails">bounty program page at HackerOne</a>. This will deliver a message to the security team. Your report will be acknowledged before or during our monthly security meeting depending on severity. We will indicate next steps in handling your report in our response.</p>
+        <p>After the initial reply to your report the security team will endeavor to keep you informed of the progress being made towards a fix and full announcement.</p>
+        <p>If you have not received a reply to your email within 30 days there are a few steps you can take:</p>
         <ul>
           <li>Send an email to the security reports list <a href="mailto:security@rubyonrails.org">security@rubyonrails.org</a>.</li>
           <li>Contact the current security coordinator <a href="mailto:rafaelmfranca@gmail.com">Rafael França</a> directly.</li>


### PR DESCRIPTION
As discussed in our monthly meeting yesterday, update the policy to not say we'll respond within a such a short timeframe. If it's severe we probably will but promising 24 to 48 hours for any security report is not accurate, we often only respond during our monthly review.