### PR TITLE
add description to conference landing page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,6 +58,10 @@ defaults:
       path: "world/2024"
     values:
       description: September 26 & 27 - Toronto, CA
+  - scope:
+      path: "world/2025"
+    values:
+      description: September 4 & 5 - Beurs van Berlage, Amsterdam, NL
 
 markdown: kramdown
 highlighter: rouge


### PR DESCRIPTION
@AmandaPerino The description is missing for the new landing page and when the link is shared, the main page's description is used the open-graph text. 