### PR TITLE
Fixing some cascade issues on common-content to foundation member

### DIFF
--- a/_layouts/company.html
+++ b/_layouts/company.html
@@ -22,7 +22,7 @@ layout: default
 
       {% if page.member_status %}
         <section class="member-status common-padding--bottom-small">
-          <p>{{ page.member_status | markdownify }}</p>
+          {{ page.member_status | markdownify }}
         </section>
       {% endif %}
 

--- a/_sass/modules/_company.scss
+++ b/_sass/modules/_company.scss
@@ -20,6 +20,9 @@
   }
 
   header.company-header {
+    margin-bottom: 0;
+    padding-bottom: 0;
+
     p {
       font-size: 24px;
       font-weight: 200;
@@ -37,7 +40,7 @@
   }
 
   h3 {
-    margin-bottom: 0.5em;
+    margin-bottom: 0;
   }
 
   aside {
@@ -58,7 +61,7 @@
       flex-basis: 49%;
       font-size: 20px;
       line-height: 1.75em;
-      margin: 0.25em 0;
+      margin: 1em 0 0.25em 0;
       padding: 0.4em 0.4em 0.4em 55px;
       white-space: nowrap;
       overflow: hidden;
@@ -77,6 +80,8 @@
 
       p {
         font-size: 18px;
+        margin-bottom: 0;
+        padding-bottom: 0;
         text-align: center;
 
         b {
@@ -92,12 +97,15 @@
       grid-template-columns: 70px 1fr;
       grid-column-gap: 10px;
       font-size: 18px;
+      padding-bottom: 0;
 
       dt {
-        font-weight: normal
+        font-weight: normal;
+        font-size: 18px;
       }
 
       dd {
+        color: #000;
         font-weight: bold;
 
         span {
@@ -110,17 +118,20 @@
 
         p {
           font-size: 18px;
+          margin-bottom: 0;
+          padding-bottom: 0;
         }
       }
     }
   }
 
   blockquote {
+    border: none;
 
     p {
       font-style: italic;
-      font-size: 18px;
       text-align: center;
+      text-wrap: balance;
   
       &::before {
         content: "“";
@@ -153,6 +164,7 @@
       font-size: 24px;
       line-height: 1.1em;
       text-align: center;
+      text-wrap: balance;
     }
   }
 
@@ -173,6 +185,9 @@
       display: flex;
       flex-direction: column;
       justify-content: space-between;
+      list-style-type: none;
+      padding: 0;
+      margin: 0;
       
       li {
         background-color: #F8F9FA;
@@ -210,6 +225,11 @@
   }
 
   .community-involvement {
+    ul {
+      list-style-type: none;
+      padding: 0;
+      margin: 0;
+    }
   }
 
   @media (min-width: 1024px) {
@@ -248,6 +268,8 @@
     }
 
     .contributions {
+      padding: 1em;
+      margin-bottom: 60px;
       h2 {
         // font-size: 36px;
       }


### PR DESCRIPTION
Fixed a variety of cached UI issues:

- Explicitly set `list-style-type` on elements coming out of markdownify
- Improved text balance on member status and pull quotes
- Fixed spacing between elements
- Fixed font size regression on pullquote body
- Ensured body copy on contribution string (non github links) is same as rest of body
- Corrected missing styling on Case Study call out

![Screenshot 2025-04-02 at 10-10-06 Ruby on Rails — Cookpad](https://github.com/user-attachments/assets/bf0b0eb8-7a82-4f7c-8b4f-c59d6c7dc987)
![Screenshot 2025-04-02 at 10-14-47 Ruby on Rails — Tablecheck](https://github.com/user-attachments/assets/f1bf0a52-ca90-4763-a96b-385908d28cd7)
![Screenshot 2025-04-02 at 10-14-32 Ruby on Rails — Doximity](https://github.com/user-attachments/assets/2dc1538f-c118-47bd-8f70-47d5f4e42bee)
