### PR TITLE
Convert blog post titles to h1 while keeping the styles

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,7 +11,7 @@
     <div class="container">
       <div class="post__headline common-headline">
         <h5>{{ page.date | date: '%A, %B %-d, %Y' }}</h5>
-        <h2>{{ page.title | strip_html }}</h2>
+        <h1>{{ page.title | strip_html }}</h1>
 {% if page.author %}
         <h6>Posted by {{ page.author }}</h6>
 {% endif %}

--- a/_sass/modules/_post.scss
+++ b/_sass/modules/_post.scss
@@ -12,6 +12,11 @@
     margin: -7px 30px -6px 30px;
     text-align: center;
 
+    h1 {
+      font-size: 55px;
+      line-height: 52px;
+    }
+
     h5 {
       margin-bottom: 16px;
     }

--- a/category/foundation.html
+++ b/category/foundation.html
@@ -10,7 +10,7 @@ redirect_from:
 <div class="heading common-padding--bottom-small common-padding--top-small">
   <div class="container">
     <div class="heading__body">
-      <div class="heading__headline common-headline">
+      <div class="post__headline common-headline">
         <h1>{{ page.title }}</h1>
       </div>
     </div>

--- a/category/news.html
+++ b/category/news.html
@@ -10,7 +10,7 @@ redirect_from:
 <div class="heading common-padding--bottom-small common-padding--top-small">
   <div class="container">
     <div class="heading__body">
-      <div class="heading__headline common-headline">
+      <div class="post__headline common-headline">
         <h1>{{ page.title }}</h1>
       </div>
     </div>

--- a/category/releases.html
+++ b/category/releases.html
@@ -10,7 +10,7 @@ redirect_from:
 <div class="heading common-padding--bottom-small common-padding--top-small">
   <div class="container">
     <div class="heading__body">
-      <div class="heading__headline common-headline">
+      <div class="post__headline common-headline">
         <h1>{{ page.title }}</h1>
       </div>
     </div>


### PR DESCRIPTION
This PR addresses this [SEO task](https://3.basecamp.com/4529592/buckets/41325723/todos/8488864382)

- Update the blog post tiles and "category" headings while are displayed in the same location on /blog
- Update styles to maintain current font size and weight, otherwise the blog post titles look too huge (screenshot attached).