### PR TITLE
Adopt the Ruby community guidelines for conduct

### DIFF
--- a/_pages/conduct.html
+++ b/_pages/conduct.html
@@ -1,5 +1,5 @@
 ---
-title: Code of Conduct
+title: Community Guidelines for Conduct
 description:
 permalink: /conduct
 redirect_from:
@@ -10,8 +10,7 @@ redirect_from:
   <div class="container">
     <div class="heading__body">
       <div class="heading__headline common-headline">
-        <h1>Code of Conduct.</h1>
-        <h4>Rails is committed to fostering a welcoming community. If you encounter any unacceptable behavior, follow these steps to report the issue to the Core team. <strong>We are here to help.</strong></h4>
+        <h1>Community Guidelines for Conduct.</h1>
       </div>
     </div>
   </div>
@@ -21,41 +20,14 @@ redirect_from:
   <div class="container">
     <div class="text__body">
       <div class="text__content common-content">
-        <h3>Our Pledge</h3>
-        <p>In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.</p>
-        <hr class="divider" />
-        <h3>Our Standards</h3>
-        <h6>Examples of behaviour that contributes to creating a positive environment include:</h6>
+        <p>Rails follows <a href="https://www.ruby-lang.org/en/conduct/">the Ruby guidelines for conduct</a> in all collaborative spaces, such as mailing lists, submitted patches, commit comments:</p>
         <ul>
-          <li>Using welcoming and inclusive language</li>
-          <li>Being respectful of differing viewpoints and experiences</li>
-          <li>Gracefully accepting constructive criticism</li>
-          <li>Focusing on what is best for the community</li>
-          <li>Showing empathy towards other community members</li>
+          <li>Participants are expected to be tolerant of opposing views.</li>
+          <li>Participants must ensure that their language and actions are free from personal attacks and disparaging remarks.</li>
+          <li>When interpreting the words and actions of others, participants should always assume good intentions.</li>
+          <li>Behavior that could reasonably be considered harassment will not be tolerated.</li>
         </ul>
-        <h6>Examples of unacceptable behaviour by participants include:</h6>
-        <ul>
-          <li>The use of sexualized language or imagery and unwelcome sexual attention or advances</li>
-          <li>Trolling, insulting/derogatory comments, and personal or political attacks</li>
-          <li>Public or private harassment</li>
-          <li>Publishing others’ private information, such as a physical or electronic address, without explicit permission</li>
-          <li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
-        </ul>
-        <hr class="divider" />
-        <h3>Our Responsibilities</h3>
-        <p>Project maintainers are responsible for clarifying the standards of acceptable behaviour and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behaviour.</p>
-        <p>Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviours that they deem inappropriate, threatening, offensive, or harmful.</p>
-        <hr class="divider" />
-        <h3>Scope</h3>
-        <p>This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.</p>
-        <hr class="divider" />
-        <h3>Enforcement</h3>
-        <p>Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at <a href="mailto:conduct@rubyonrails.org">conduct@rubyonrails.org</a>. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.</p>
-        <p>Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.</p>
-        <hr class="divider" />
-        <h3>Attribution</h3>
-        <p>This Code of Conduct is adapted from the <a href="https://contributor-covenant.org">Contributor Covenant</a>, version 1.4, available at <a href="https://contributor-covenant.org/version/1/4">https://contributor-covenant.org/version/1/4</a>.</p>
-        <p>For a history of updates and revisions to this policy, see the <a href="https://github.com/rails/website/commits/main/_pages/conduct.html">page history</a>.</p>
+        <p>If you believe these guidelines have been violated, you can email conduct@rubyonrails.org to alert The Rails Foundation.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
They're much simpler and we get a uniform standard across Ruby and Rails.