### PR TITLE
Remove quotes from titles

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,7 +23,7 @@
 {% assign url = page.url  | absolute_url %}
 
 <head>
-  <title>"{{ title }}"</title>
+  <title>{{ title }}</title>
   <meta charset="utf-8" />
   <meta content="ie=edge" http-equiv="x-ua-compatible" />
   <meta name="handheldfriendly" content="true" />


### PR DESCRIPTION
This PR is to remove the unwanted quotes around site titles as mentioned in [this SEO task](https://3.basecamp.com/4529592/buckets/41325723/todos/8488855181#__recording_8677984037)