### PR TITLE
feat: add Intercom widget to rails world 2025 pages

### DIFF
--- a/_includes/world/2025/head.html
+++ b/_includes/world/2025/head.html
@@ -74,6 +74,15 @@
     })
   </script>
 
+  <script>
+    window.intercomSettings = {
+      api_base: "https://api-iam.intercom.io",
+      app_id: "rubyonrails",
+    };
+
+    (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/rubyonrails';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(document.readyState==='complete'){l();}else if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+  </script>
+
   <link rel="icon" href="/assets/images/favicon.ico" />
   <link rel="apple-touch-icon" type="image/png" href="/assets/images/apple-touch-icon.png" />
   <link rel="stylesheet" href="https://use.typekit.net/lar2lzk.css">


### PR DESCRIPTION
## Context
Every year, people who come to Rails World have questions about the conference and tickets. Right now, @AmandaPerino answers all these questions, so her inbox gets very full. This year, we want to use [Intercom](https://www.intercom.com/) to help with this problem.

This pull request adds the Intercom Widget to the header of the 2025 pages.

**Note:** Right now, this widget is set to be off within Intercom. If this pull request is merged and deployed, you will not see any changes yet. There is still work to do in Intercom. For example, we need to create a knowledge base for Fin.

## How it looks on the website

https://github.com/user-attachments/assets/419db00f-2c1f-4255-bf79-6de97c0677fa

## Intercom article
https://www.intercom.com/help/en/articles/167-install-intercom-for-visitors-and-leads-on-web
