### PR TITLE
refactor: remove tito script tag from RW 2025 pages header

### DIFF
--- a/_includes/world/2025/head.html
+++ b/_includes/world/2025/head.html
@@ -85,5 +85,4 @@
   <link
     href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap"
     rel="stylesheet">
-  <script src='https://js.tito.io/v2/with/inline' async></script>
 </head>


### PR DESCRIPTION
## Context
This pull request takes out the Tito script tag from the header of the Rails World 2025 pages, which is for the Tito widget (while it was not used this year).

## Tito article
https://ti.to/docs/api/widget/#tito-widget-v2