### PR TITLE
Tweak asset path for judge.me

### DIFF
--- a/_data/world/2025/sponsors.yml
+++ b/_data/world/2025/sponsors.yml
@@ -93,7 +93,7 @@ members:
     logo: /assets/world/2024/images/sponsors/RW-logo-fleetio.svg
     url: https://www.fleetio.com/
   - name: Judge.me
-    logo: assets/images/logo-judgeme.svg
+    logo: /assets/images/logo-judgeme.svg
     url: https://judge.me/
   - name: Procore
     logo: /assets/world/2024/images/sponsors/RW-logo-procore.svg


### PR DESCRIPTION
The logo returns a 404 otherwise 😅 

<img width="167" alt="image" src="https://github.com/user-attachments/assets/099963d9-2203-4c1a-8b31-6593041442fc" />

cc/ @AmandaPerino 