### PR TITLE
Fix 404 when Navigating from Deutsch -> English on Rails Doctrine

### DIFF
--- a/doctrine/de.html
+++ b/doctrine/de.html
@@ -34,7 +34,7 @@ redirect_from:
           <div class="language__options">
             <ul>
               <li lang="en">
-                <a href="/doctrine/"><span>English</span></a>
+                <a href="/doctrine"><span>English</span></a>
               </li>
               <li lang="es">
                 <a href="/doctrine/es"><span>Español</span></a>


### PR DESCRIPTION
Remove trailing slash on the English selection to remove 404 when navigating from Deutsch -> English

Addresses #528 