### PR TITLE
Fix JavaScript console errors on Rails World 2024 page

### DIFF
--- a/_includes/world/2024/head.html
+++ b/_includes/world/2024/head.html
@@ -57,22 +57,8 @@
   </script>
   <script defer data-domain="rubyonrails.org" src="https://plausible.io/js/script.js"></script>
 
-  <script src="/assets/world/2023/scripts/back_to_top.js" defer></script>
-  <script src="/assets/world/2023/scripts/carousel.js" defer></script>
-  <script src="/assets/world/2023/scripts/modal_component.js" defer></script>
-
-  <script type="module">
-    import hotwiredTurbo from 'https://cdn.skypack.dev/@hotwired/turbo';
-  </script>
-
-  <script type="text/javascript">
-    document.addEventListener("turbo:click", (event) => {
-      if (event.srcElement.closest("modal-component")) {
-        event.preventDefault()
-        Turbo.visit(event.detail.url)
-      }
-    })
-  </script>
+  <!-- Rails World 2024 specific scripts -->
+  <!-- Note: Removed unused component scripts that were causing console errors -->
 
   <link rel="icon" href="/assets/images/favicon.ico" />
   <link rel="apple-touch-icon" type="image/png" href="/assets/images/apple-touch-icon.png" />

--- a/_includes/world/2024/slideshow.html
+++ b/_includes/world/2024/slideshow.html
@@ -33,6 +33,11 @@
 
     function generateDots(slidesLength) {
         const dotsContainer = document.querySelector(".dotsContainer");
+        
+        if (!dotsContainer) {
+            console.warn("Slideshow: .dotsContainer not found");
+            return;
+        }
 
         for (let i = 0; i < slidesLength; i++) {
             const dot = document.createElement("button");
@@ -52,6 +57,11 @@
     function showSlides(index) {
         const dots = document.getElementsByClassName("dot");
 
+        if (!slides.length) {
+            console.warn("Slideshow: No slides found");
+            return;
+        }
+
         if (index > slides.length) {
             currentSlideIndex = 1;
         } else if (index <= 0) {
@@ -69,9 +79,14 @@
             }
         }
 
-        slides[currentSlideIndex - 1].style.display = "flex";
-        slides[currentSlideIndex - 1].ariaHidden = false;
-        dots[currentSlideIndex - 1].classList.add("active")
+        if (slides[currentSlideIndex - 1]) {
+            slides[currentSlideIndex - 1].style.display = "flex";
+            slides[currentSlideIndex - 1].ariaHidden = false;
+        }
+        
+        if (dots[currentSlideIndex - 1]) {
+            dots[currentSlideIndex - 1].classList.add("active")
+        }
     }
 
     function forwardSlide() {
@@ -84,6 +99,11 @@
         showSlides(currentSlideIndex);
     }
 
-    generateDots(slides.length);
-    showSlides(currentSlideIndex);
+    // Initialize slideshow only if elements exist
+    if (slides.length > 0) {
+        generateDots(slides.length);
+        showSlides(currentSlideIndex);
+    } else {
+        console.warn("Slideshow: No slides found, skipping initialization");
+    }
 </script>

--- a/_includes/world/2024/tito-widget.html
+++ b/_includes/world/2024/tito-widget.html
@@ -13,5 +13,11 @@
         : "rails-world/rails-world-2024";
 
     window.tito = window.tito || function () { (tito.q = tito.q || []).push(arguments); };
-    tito("widget.mount", { el: "#tito-widget", event })
+    
+    // Only mount Tito widget if the element exists
+    if (document.getElementById("tito-widget")) {
+        tito("widget.mount", { el: "#tito-widget", event })
+    } else {
+        console.info("Tito widget element not found, skipping mount");
+    }
 </script>


### PR DESCRIPTION
## Summary
- Fixes JavaScript console errors reported in #254 on the Rails World 2024 page
- Removes references to non-existent 2023 component scripts
- Adds defensive checks to prevent errors when DOM elements are missing

## Changes Made

### `/Users/sward/work/contrib/website/_includes/world/2024/head.html`
- Removed script imports for non-existent files:
  - `/assets/world/2023/scripts/back_to_top.js`
  - `/assets/world/2023/scripts/carousel.js`
  - `/assets/world/2023/scripts/modal_component.js`
- Removed unused Hotwired Turbo imports and event handlers

### `/Users/sward/work/contrib/website/_includes/world/2024/slideshow.html`
- Added null checks for DOM elements before manipulation
- Added console warnings when expected elements aren't found
- Only initializes slideshow when slides actually exist

### `/Users/sward/work/contrib/website/_includes/world/2024/tito-widget.html`
- Added check for `#tito-widget` element existence before mounting
- Added informative console message when widget element isn't found

## Test plan
- [x] Ran Jekyll locally and verified the page loads without console errors
- [x] Tested with Playwright to confirm no JavaScript errors in console
- [x] Verified all functionality (slideshow, Tito widget) still works as expected
- [x] Only harmless Plausible analytics warning appears when running locally

Fixes #254