### PR TITLE
Re-enable jekyll-redirect-from to fix trailing slash redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site
+.bundle
 .nova
 .sass-cache
 .jekyll-cache

--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ We do not, however, take pull requests for updating the list of highlighted Rail
 2. `bundle exec jekyll serve --livereload`
 3. Go to `http://localhost:4000/`
 
-Note for local dev: The Jekyll redirect plugin is broken, so if you experience a redirect loop on any given page alternating between a string ending with and without a `/`, disable `- jekyll-redirect-from` in `_config.yml` and the page will load. The server will not be able to tell `/docs/` from `/docs` so if you experience a 404, remove or add the trailing `/`. Please be sure to NOT commit this change during your development work.
+> [!NOTE]
+> The Jekyll redirect plugin is broken in development, so if you experience a redirect loop on any page (alternating between URLs with and without a trailing `/`), disable `- jekyll-redirect-from` in `_config.yml` and the page will load. Note that the server won't distinguish between `/docs/` and `/docs`, so if you get a 404, try adding or removing the trailing `/`. Please don't commit this change during development.

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ world25_title: Rails World 2025 - Amsterdam, NL
 plugins:
   - jekyll-feed
   - jekyll-paginate
-  # - jekyll-redirect-from
+  - jekyll-redirect-from
   - jekyll-sitemap
   - jemoji
 


### PR DESCRIPTION
I was reading through https://public.3.basecamp.com/p/XUosqWXyTwWjb5Dve9SCSo3f and noticed that clicking the link there (https://rubyonrails.org/conduct/) returns a 404, but removing the trailing slash returns a 200.

I tracked the issue down to the `jekyll-redirect-from` plugin being commented out in `_config.yml`. Based on the related README entry that was added in https://github.com/rails/website/commit/4347cbdc44e65fecf12b3371e08cc47bb48e8fd2, it appears this plugin was unintentionally commented out (likely for local development purposes) and never re-enabled.

This change uncomments the `jekyll-redirect-from` plugin to restore proper handling of trailing slash redirects across the site, including the `/conduct/` → `/conduct` redirect mentioned in the Basecamp post.