### PR TITLE
Fix the dates of the supported releases in "Bug Fixes"

### DIFF
--- a/_pages/maintenance.html
+++ b/_pages/maintenance.html
@@ -32,8 +32,8 @@ redirect_from:
           unsupported.</p>
         <h6>List of currently supported releases</h6>
         <ul>
-          <li><strong>8.0.x</strong> - Supported until November 7, 2025</li>
-          <li><strong>7.2.x</strong> - Supported until August 9, 2025</li>
+          <li><strong>8.0.x</strong> - Supported until November 7, 2026</li>
+          <li><strong>7.2.x</strong> - Supported until August 9, 2026</li>
         </ul>
         <h3 id="security">Security Issues</h3>
         <p>


### PR DESCRIPTION
On the [maintenance page](https://rubyonrails.org/maintenance) the years used for Rails versions in `Bug Fixes` are incorrectly set to 2025 instead of 2026. The dates should match those used in `Security Issues`.

<img width="829" height="940" alt="Screenshot 2025-09-24 at 13 25 26" src="https://github.com/user-attachments/assets/bf6b2982-56c7-4bcf-8d99-b4cf6abc961d" />


