### PR TITLE
Add mailto link for email address in conduct.html

### DIFF
--- a/_pages/conduct.html
+++ b/_pages/conduct.html
@@ -27,7 +27,7 @@ redirect_from:
           <li>When interpreting the words and actions of others, participants should always assume good intentions.</li>
           <li>Behavior that could reasonably be considered harassment will not be tolerated.</li>
         </ul>
-        <p>If you believe these guidelines have been violated, you can email conduct@rubyonrails.org to alert The Rails Foundation.</p>
+        <p>If you believe these guidelines have been violated, you can email <a href="mailto:conduct@rubyonrails.org">conduct@rubyonrails.org</a> to alert The Rails Foundation.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The email address at the bottom of the community guidelines for conduct is plain text instead of a `mailto:` link. Maybe that was intentional, but if not, this adds a link in.