### PR TITLE
Fix incorrect `lang` attributes

### DIFF
--- a/doctrine/de.html
+++ b/doctrine/de.html
@@ -42,7 +42,7 @@ redirect_from:
               <li lang="es">
                 <a href="/doctrine/fr"><span>Français</span></a>
               </li>
-              <li lang="en">
+              <li lang="ru">
                 <a href="/doctrine/ru"><span>Russian</span></a>
               </li>
               <li lang="zh-CN">

--- a/doctrine/es.html
+++ b/doctrine/es.html
@@ -27,7 +27,7 @@ redirect_from:
               <li lang="de"><a href="/doctrine/de"><span>Deutsch</span></a></li>
               <li lang="en"><a href="/doctrine"><span>English</span></a></li>
               <li lang="fr"><a href="/doctrine/fr"><span>Français</span></a></li>
-              <li lang="en"><a href="/doctrine/ru"><span>Russian</span></a></li>
+              <li lang="ru"><a href="/doctrine/ru"><span>Russian</span></a></li>
               <li lang="zh-CN"><a href="/doctrine/zh_cn"><span>简体中文</span></a></li>
               <li lang="zh-TW"><a href="/doctrine/zh_tw"><span>繁體中文</span></a></li>
             </ul>

--- a/doctrine/fr.html
+++ b/doctrine/fr.html
@@ -27,7 +27,7 @@ redirect_from:
               <li lang="en"><a href="/doctrine"><span>English</span></a></li>
               <li lang="de"><a href="/doctrine/de"><span>Deutsch</span></a></li>
               <li lang="es"><a href="/doctrine/es"><span>Español</span></a></li>
-              <li lang="en"><a href="/doctrine/ru"><span>Russian</span></a></li>
+              <li lang="ru"><a href="/doctrine/ru"><span>Russian</span></a></li>
               <li lang="zh-CN"><a href="/doctrine/zh_cn"><span>简体中文</span></a></li>
               <li lang="zh-TW"><a href="/doctrine/zh_tw"><span>繁體中文</span></a></li>
             </ul>

--- a/doctrine/index.html
+++ b/doctrine/index.html
@@ -27,7 +27,7 @@ redirect_from:
             <li lang="de"><a href="/doctrine/de"><span>Deutsch</span></a></li>
             <li lang="es"><a href="/doctrine/es"><span>Español</span></a></li>
             <li lang="fr"><a href="/doctrine/fr"><span>Français</span></a></li>
-            <li lang="en"><a href="/doctrine/ru"><span>Russian</span></a></li>
+            <li lang="ru"><a href="/doctrine/ru"><span>Russian</span></a></li>
             <li lang="zh-CN"><a href="/doctrine/zh_cn"><span>简体中文</span></a></li>
             <li lang="zh-TW"><a href="/doctrine/zh_tw"><span>繁體中文</span></a></li>
           </ul>

--- a/doctrine/zh_cn.html
+++ b/doctrine/zh_cn.html
@@ -28,8 +28,8 @@ redirect_from:
               <li lang="de"><a href="/doctrine/de"><span>Deutsch</span></a></li>
               <li lang="es"><a href="/doctrine/es"><span>Español</span></a></li>
               <li lang="fr"><a href="/doctrine/fr"><span>Français</span></a></li>
-              <li><a href="/doctrine/ru"><span>Russian</span></a></li>
-              <li><a href="/doctrine/zh_tw"><span>繁體中文</span></a></li>
+              <li lang="ru"><a href="/doctrine/ru"><span>Russian</span></a></li>
+              <li lang="zh-TW"><a href="/doctrine/zh_tw"><span>繁體中文</span></a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Several doctrine pages incorrectly used `lang="en"` or omitted the `lang` attribute for the Russian link. This commit corrects them to `lang="ru"` for consistency with other languages.