### PR TITLE
Prevent redirect loop in the Rails Doctrine (ja)

### DIFF
--- a/doctrine/ja.html
+++ b/doctrine/ja.html
@@ -2,7 +2,7 @@
 title: The Rails Doctrine
 permalink: /doctrine/ja
 redirect_from:
-  - /doctrine/ja
+  - /doctrine/ja/
 ---
 
 <div class="heading common-padding--bottom common-padding--top common-shape--bottom-grey-down-left">


### PR DESCRIPTION
A redirect loop occurred because `permalink` and `redirect_from` were identical. To align with other locales, a trailing slash has been added to the `redirect_from` path.