### PR TITLE
Sync zh-TW Doctrine with English: remove outdated Majestic Monolith link

### DIFF
--- a/doctrine/zh_tw.html
+++ b/doctrine/zh_tw.html
@@ -339,10 +339,8 @@ redirect_from:
       <div class="text__body">
         <div class="text__content common-content">
           <h3 id="integrated-systems">重視整合系統</h3>
-          <p>Rails 可以在很多場景下使用，但最初是用來做整合系統的 <a
-                  href="https://m.signalvnoise.com/the-majestic-monolith-29166d022228#.umpdeapqa">Majestic Monolith</a>！Majestic
-            Monolith 即用一個系統來解決所有問題。這表示 Rails 從需要做即時刷新的前端 JavaScript，到資料庫如何在生產環境遷移一個版本，都要納入考量。
-          </p>
+          <p>Rails 可以在許多場景下使用，但它最初的理念是打造整合系統：Majestic Monolith，也就是以單一完整系統處理所有功能的架構。
+            這表示 Rails 從需要做即時刷新的前端 JavaScript，到資料庫如何在生產環境遷移一個版本，都要納入考量。</p>
           <p>我們已經談過，這是多麼廣闊的眼界。但對於一人團隊來說，不過就是現實的考量而已。Rails
             特別尋找通才來打造整個系統。目的不是要把專家束之高閣，而是讓通才和專家合力，打造出更具長遠價值的系統。</p>
           <p>讓一個人可以做更多的事情，才想出了整合系統。而正是在整合系統裡，我們可以拿掉許多不必要的抽象，減少抽象層之間的重複（像是


### PR DESCRIPTION
### Summary
The zh-TW version of the Rails Doctrine contained an extra external link to the “Majestic Monolith” article on Signal v. Noise, which is not present in the current English version.  
This PR aligns the zh-TW translation with the latest English version.

### Changes
- Removed the outdated external link.
- Updated the sentence to match the latest English text:
  > Rails 可以在許多場景下使用，但它最初的理念是打造整合系統：Majestic Monolith，也就是以單一完整系統處理所有功能的架構。

Thank you 🙏