### PR TITLE
Add new Wishlist tutorial to /tutorial page

### DIFF
--- a/_pages/tutorial.html
+++ b/_pages/tutorial.html
@@ -96,10 +96,10 @@ redirect_from:
           </div>
         </a>
       </div>
-      <div class="card card__coming-soon">
+      <div class="card">
         <a
-          href="https://guides.rubyonrails.org/install_ruby_on_rails.html"
-          title="Install Ruby on Rails"
+          href="https://guides.rubyonrails.org/wishlists.html"
+          title="User Wishlists"
         >
           <div class="card__body">
             <div class="card__headline">
@@ -111,9 +111,6 @@ redirect_from:
                 Save products for later, share the list for a birthday or
                 holiday, and more.
               </p>
-            </div>
-            <div class="card__label">
-              <h6>Coming Soon</h6>
             </div>
           </div>
         </a>


### PR DESCRIPTION
This PR is adjusting the copy & div blocks on the /tutorial page to prepare for the new Add-on tutorial 'wishlists.html', currently in review in the rails/rails repo: https://github.com/rails/rails/pull/55428.