### PR TITLE
fix: markdown syntax for code sample

### DIFF
--- a/_posts/2025-10-21-rails-8-1.markdown
+++ b/_posts/2025-10-21-rails-8-1.markdown
@@ -70,6 +70,7 @@ end
 ```
 
 As well as context:
+
 ```ruby
 # All events will contain context: {request_id: "abc123", shop_id: 456}
 Rails.event.set_context(request_id: "abc123", shop_id: 456)


### PR DESCRIPTION
I understand, typos (or cosmetic changes) are not very meaningful PRs, but saw this broken syntax on the website so raised a PR to fix it.

Ref: https://guides.rubyonrails.org/8_1_release_notes.html#active-job-continuations

<img width="1786" height="974" alt="CleanShot 2025-10-31 at 17 19 40@2x" src="https://github.com/user-attachments/assets/9a0158c6-316e-4387-95d2-fd0f987186b6" />
