### PR TITLE
Update security copy to remove "bounty"

### DIFF
--- a/_pages/security.html
+++ b/_pages/security.html
@@ -28,7 +28,7 @@ redirect_from:
         <p>Please see the <a href="https://guides.rubyonrails.org/maintenance_policy.html#security-issues">Maintenance policy</a> for supported versions.</p>
         <hr class="divider" />
         <h3>Reporting a Vulnerability</h3>
-        <p>All security bugs in Rails should be reported through our <a href="https://hackerone.com/rails">bounty program page at HackerOne</a>. This will deliver a message to the security team. Your report will be acknowledged before or during our monthly security meeting depending on severity. We will indicate next steps in handling your report in our response.</p>
+        <p>All security bugs in Rails should be reported through our <a href="https://hackerone.com/rails">program page at HackerOne</a>. This will deliver a message to the security team. Your report will be acknowledged before or during our monthly security meeting depending on severity. We will indicate next steps in handling your report in our response.</p>
         <p>After the initial reply to your report the security team will endeavor to keep you informed of the progress being made towards a fix and full announcement.</p>
         <p>If you have not received a reply to your email within 30 days there are a few steps you can take:</p>
         <ul>


### PR DESCRIPTION
As of March 27, 2026 the IBB is paused and no longer offering bounties for new submissions. This removes the word "bounty" as to not signal we pay a bounty at this time.