### PR TITLE
fix(world-2026): update Sorcer URL and open nav links in new tab

### DIFF
--- a/_data/world/2026/sponsors.yml
+++ b/_data/world/2026/sponsors.yml
@@ -46,7 +46,7 @@ other:
     url: "https://judoscale.com/"
   - name: "Sorcer"
     logo: /assets/world/2026/logos/logo-sorcer.png
-    url: "https://sorcer.com/"
+    url: "https://sorcer.io/"
   - name: "Typesense"
     logo: /assets/world/2026/logos/logo-typesense.png
     url: "https://typesense.org/"

--- a/_includes/world/2026/components/nav.html
+++ b/_includes/world/2026/components/nav.html
@@ -59,7 +59,7 @@
         tabindex="0"
         aria-label="Apply to speak"
       >
-        <a href="https://sessionize.com/rails-world-2026/"
+        <a href="https://sessionize.com/rails-world-2026/" target="_blank" rel="noopener noreferrer"
           ><span>Apply to speak</span></a
         >
       </div>
@@ -89,7 +89,7 @@
         tabindex="0"
         aria-label="Apply to speak"
       >
-        <a href="https://sessionize.com/rails-world-2026/"
+        <a href="https://sessionize.com/rails-world-2026/" target="_blank" rel="noopener noreferrer"
           ><span>Apply to speak</span></a
         >
       </div>


### PR DESCRIPTION
## Changes

- Update Sorcer sponsor URL from `https://sorcer.com/` to `https://sorcer.io/` in `_data/world/2026/sponsors.yml`
- Add `target="_blank" rel="noopener noreferrer"` to both "Apply to speak" anchor tags (desktop and mobile) in `_includes/world/2026/components/nav.html`