### PR TITLE
Update prospectus link and hero title line breaks

### DIFF
--- a/_includes/world/2026/homepage_sections/hero_banner.html
+++ b/_includes/world/2026/homepage_sections/hero_banner.html
@@ -1,7 +1,7 @@
 <div class="hero-banner">
   <div class="hero-inner">
     <div class="hero-text">
-      <h1>Shaping the future<br>of Ruby on Rails</h1>
+      <h1>Shaping the<br class="desktop-only"> future of<br class="desktop-only"> Ruby on Rails</h1>
       <p>
         Rails World is a <span class="bold">two-day, two track community conference</span>
         featuring technical talks, demos, networking, and keynotes about the latest features

--- a/_includes/world/2026/homepage_sections/sponsors.html
+++ b/_includes/world/2026/homepage_sections/sponsors.html
@@ -8,7 +8,7 @@
       <div class="become-sponsor__card">
         <h2 class="become-sponsor__title">Become a sponsor</h2>
         <p class="become-sponsor__text">Sponsoring Rails World means showcasing your brand to a global audience of Rails enthusiasts, developers, and industry leaders. Let's make Rails World an unforgettable experience for all.</p>
-        <a href="/assets/world/2026/files/rails-world-2026-sponsorship-prospectus.pdf" class="become-sponsor__btn" target="_blank" rel="noopener noreferrer">View prospectus</a>
+        <a href="https://public.3.basecamp.com/p/gr3BsVx9mBmfJzN36rjaprRs" class="become-sponsor__btn" target="_blank" rel="noopener noreferrer">View prospectus</a>
       </div>
       <img src="/assets/world/2026/images/sponsors/HAT.png" alt="Neon cowboy hat" class="become-sponsor__hat" loading="lazy">
     </div>

--- a/_sass/world/2026/modules/_hero_banner.scss
+++ b/_sass/world/2026/modules/_hero_banner.scss
@@ -43,6 +43,12 @@
         font-size: 36px;
         line-height: 1.1;
       }
+
+      @include media(MobileScreens) {
+        br.desktop-only {
+          display: none;
+        }
+      }
     }
 
     p {
@@ -60,7 +66,7 @@
 
   .hero-cactus {
     position: absolute;
-    left: 43%;
+    left: 40%;
     top: -54px;
     height: 210px;
     width: auto;


### PR DESCRIPTION
## Summary
- Replace prospectus PDF with Basecamp link in the sponsors section
- Update hero title to display in three lines on desktop using responsive `<br>` tags hidden on mobile

## Test plan
- [ ] Verify "View prospectus" link opens the Basecamp page
- [ ] Verify hero title shows 3 lines on desktop (≥700px)
- [ ] Verify hero title flows naturally on mobile (≤700px)