### PR TITLE
Fix tutorial layout

### DIFF
--- a/_pages/tutorial.html
+++ b/_pages/tutorial.html
@@ -19,7 +19,7 @@ redirect_from:
   </div>
 </div>
 
-<div class="docs cards common-padding--bottom-small padfix">
+<div class="docs cards">
   <div class="container">
     <h2 class="thin">Beginner</h2>
 

--- a/_sass/modules/_cards.scss
+++ b/_sass/modules/_cards.scss
@@ -44,7 +44,7 @@
       margin: 3px 15px; // Reduce side margins on mobile to prevent overflow
 
       .card {
-        max-height: auto !important;
+        max-height: none !important;
         width: 100%; // Ensure card doesn't exceed container
         box-sizing: border-box; // Include padding in width calculation
 

--- a/_sass/modules/_cards.scss
+++ b/_sass/modules/_cards.scss
@@ -325,16 +325,6 @@
     }
   }
 
-  &.padfix {
-    padding-bottom: 80px;
-  }
-
-  @media (min-width: 768px) {
-    &.padfix {
-      padding-bottom: 0;
-    }
-  }
-
   @media (min-width: 768px) {
     &__container {
       grid-template-columns: repeat(2, 1fr);

--- a/_sass/modules/_docs.scss
+++ b/_sass/modules/_docs.scss
@@ -65,7 +65,11 @@
   }
 
   .card__fullwidth .card {
-    max-height: 500px !important;
+    max-height: none !important;
+
+    @media (min-width: 768px) {
+      max-height: 500px !important;
+    }
   }
 
   // UL/LIs here are for cards, no bullets actually used.


### PR DESCRIPTION
## What changed
This PR fixes two layout bugs on the `/docs/tutorials` page:
1. The "Advanced" section was overlapping onto the full-width "Beginner" card on intermediate screen widths (e.g., when viewing the site in a narrow browser window or split-screen mode). The content of the "Beginner" card grew taller than the container, causing the next section to render on top of it.
2. After fixing the overlap, there was an unnaturally large gap between the "Beginner" and "Advanced" sections.

## How it works
1. **Fixed CSS Specificity:** The `_docs.scss` file contained a global `max-height: 500px` for `.card__fullwidth .card` that loaded *after* the mobile-specific`max-height: none` styles in `_cards.scss`, trapping the content. I updated `_docs.scss` to only apply the 500px limit on viewports `768px` and wider.
2. **Fixed Section Spacing:** I removed the `padfix` class (an old CSS workaround) and the `common-padding--bottom-small` class from the first section's container. Removing the padding class removes the artificial 60px gap between the two sections, allowing them to flow with normal spacing while keeping their separate HTML containers intact.

<img width="640" height="416" alt="Before_and_After Medium" src="https://github.com/user-attachments/assets/3b3b29be-5c98-44cf-ae48-7ab2932f4d40" />
