### PR TITLE
fix: keep "On Rails" together with nbsp on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,7 +409,7 @@ end
       <div class="text__content common-content common-content--size-large">
         <p><strong>Learn more</strong> about <a href="https://hotwired.dev">Hotwire</a> — the default front-end framework for Rails</p>
 
-        <p><strong>Stay up to date</strong> with Rails on <a href="https://x.com/rails">X</a>, <a href="https://www.youtube.com/@railsofficial">YouTube</a>, <a href="https://world.hey.com/this.week.in.rails">This Week in Rails</a>, or the <a href="https://podcast.rubyonrails.org/">On Rails podcast</a>.</p>
+        <p><strong>Stay up to date</strong> with Rails on <a href="https://x.com/rails">X</a>, <a href="https://www.youtube.com/@railsofficial">YouTube</a>, <a href="https://world.hey.com/this.week.in.rails">This Week in Rails</a>, or the <a href="https://podcast.rubyonrails.org/">On&nbsp;Rails podcast</a>.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## What

On the homepage "Stay up to date" line, the **On Rails** podcast link could wrap between "On" and "Rails". This adds a non-breaking space so the podcast's name stays together.

## Why

"On Rails" is the podcast's title and reads awkwardly when split across lines. "podcast" is left to wrap normally.

Before:
<img width="1142" height="210" alt="image" src="https://github.com/user-attachments/assets/ea12010c-f48e-4c49-a013-d959c2d97c62" />


## Change

- `index.html`: `On Rails` → `On&nbsp;Rails` in the podcast link text.

After:
<img width="891" height="235" alt="image" src="https://github.com/user-attachments/assets/5732a7c3-6fb7-4bfc-b849-15f3f15b614e" />



🤖 Co-authored with Claude Code