### PR TITLE
fix(word-2026): Feature/agenda page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,6 +70,11 @@ defaults:
       type: "world_speakers"
     values:
       layout: "world/2026/speaker"
+  - scope:
+      path: "_world_sessions/2026"
+      type: "world_sessions"
+    values:
+      layout: "world/2026/session"
 
 markdown: kramdown
 highlighter: rouge

--- a/_data/world/2026/schedule.yml
+++ b/_data/world/2026/schedule.yml
@@ -3,15 +3,17 @@ days:
     label: "SEPT 22"
     date: "September 22, 2026"
     sessions:
-      - time: "All Day"
+      - time: "9:00 AM"
         type: info
         title: "Rails at Scale Summit"
         location: "Private"
+        description: "Invite only. Ticket holders will be sent more information."
 
-      - time: "Evening"
+      - time: "4:00 PM"
         type: info
         title: "Pre-Registration, sponsored by Clio"
         location: "The Line Hotel"
+        description: "A place to grab your badge and a drink and meet other attendees before we kick off Day 1."
 
   - id: sept23
     label: "SEPT 23"
@@ -279,6 +281,7 @@ days:
         type: info
         title: "Community Game Night"
         location: "The Line Hotel"
+        description: "Badge holders only; more info shared soon."
 
   - id: sept24
     label: "SEPT 24"
@@ -534,3 +537,4 @@ days:
         type: info
         title: "Closing Party, sponsored by Shopify & Procore"
         location: "Banger's"
+        description: "Badge holders only."


### PR DESCRIPTION
 Rails World 2026 — Agenda & Speaker Pages

  New features

  - Agenda page (/world/2026/agenda) with tabbed navigation by day (Sept 22, 23, 24), session cards with neon glow styling, and tag pills
  - Individual session pages (/world/2026/sessions/[slug]) with speaker photos, bio links, day/time/track chips, and description
  - Speaker talk cards on each speaker profile page 
  - Clickable speaker names on the agenda, including dual-speaker sessions (Matz & DHH, Alicia & Arely Rivera)
  - Sept 22 tab (Rails at Scale Summit + Pre-Registration) with times and descriptions
  - Active day tab is visually highlighted

  Content updates

  - Added MC speakers: Nathan Hessler and Michelle Yuen
  - Added Yukihiro "Matz" Matsumoto as keynote speaker
  - Updated sponsor tiers: new platinum layout (2 columns), updated logos for Procore, Dell, JetBrains, GiftHealth, Poll Everywhere, Cloudflare
  - Rails at Scale Summit sponsor section updated (Shopify, Procore, Cloudflare)
  - Added event descriptions for Game Night, Closing Party, Pre-Registration, and Rails at Scale

  Fixes

  - Removed Code of Conduct banner from speakers and agenda pages
  - Speaker link rendering extracted into reusable speaker_links.html include
  - Session times stripped of leading zeros (01:30 PM → 1:30 PM)
