### PR TITLE
Update latest version to 8.1.3.1

### DIFF
--- a/_data/version.yml
+++ b/_data/version.yml
@@ -1,3 +1,3 @@
-label: Rails 8.1.3
-date: March 24, 2026
-url: 2026/3/24/Rails-Versions-8-0-5-and-8-1-3-have-been-released
+label: Rails 8.1.3.1
+date: July 29, 2026
+url: 2026/7/29/Rails-Versions-7-2-3-2-8-0-5-1-and-8-1-3-1-have-been-released


### PR DESCRIPTION
Follow up of https://github.com/rails/website/commit/7d77ab.

This PR updates the latest Rails version announcement link to 8.1.3.1. https://rubyonrails.org/2026/7/29/Rails-Versions-7-2-3-2-8-0-5-1-and-8-1-3-1-have-been-released