### PR TITLE
Link to Rails AI evaluation suite

### DIFF
--- a/_pages/ai.html
+++ b/_pages/ai.html
@@ -142,6 +142,7 @@ redirect_from:
 
         <div class="ai__benchmark-report">
           <a href="https://rubyonrails.org/category/agents" class="common-button common-button--color-red"><span>Read the most recent benchmark report</span></a>
+          <p>Explore the open-source <a href="https://github.com/rails/ai-evals">Rails AI evaluation suite</a>.</p>
         </div>
 
         <div class="ai__methodology">

--- a/_pages/ai.html
+++ b/_pages/ai.html
@@ -142,12 +142,12 @@ redirect_from:
 
         <div class="ai__benchmark-report">
           <a href="https://rubyonrails.org/category/agents" class="common-button common-button--color-red"><span>Read the most recent benchmark report</span></a>
-          <p>Explore the open-source <a href="https://github.com/rails/ai-evals">Rails AI evaluation suite</a>.</p>
         </div>
 
         <div class="ai__methodology">
           <h3>Methodology</h3>
           <p>Each model ran every evaluation three times in August 2026, using the provider's default settings — 63 runs per model. Accuracy is the share of runs that passed the evaluation's hidden tests; refusals count as failures, and differences of a few points between models are within run-to-run noise. Speed is the median run duration, and tokens and cost are means per run. API recall is the percentage of runs in which the model reached directly for the target Rails API. Model-level medians come from run-level data, so they can differ slightly from the per-evaluation timings. Select any model or result for the underlying evaluation details.</p>
+          <p>Explore the open-source <a href="https://github.com/rails/ai-evals">Rails AI evaluation suite</a>.</p>
         </div>
       </section>
 

--- a/_sass/modules/_ai.scss
+++ b/_sass/modules/_ai.scss
@@ -835,24 +835,6 @@ body.ai-dialog-open {
   &__benchmark-report {
     margin: 28px auto 0;
     text-align: center;
-
-    p {
-      color: $color-grey-5;
-      font-size: 16px;
-      line-height: 22px;
-      margin-top: 14px;
-
-      a {
-        color: $color-black;
-        font-weight: 700;
-        text-decoration: underline;
-        text-decoration-thickness: 2px;
-
-        &:hover {
-          color: $color-red;
-        }
-      }
-    }
   }
 
   &__methodology {
@@ -874,6 +856,21 @@ body.ai-dialog-open {
       color: $color-grey-5;
       font-size: 17px;
       line-height: 26px;
+
+      + p {
+        margin-top: 14px;
+      }
+
+      a {
+        color: $color-black;
+        font-weight: 700;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+
+        &:hover {
+          color: $color-red;
+        }
+      }
     }
 
     code {

--- a/_sass/modules/_ai.scss
+++ b/_sass/modules/_ai.scss
@@ -835,6 +835,24 @@ body.ai-dialog-open {
   &__benchmark-report {
     margin: 28px auto 0;
     text-align: center;
+
+    p {
+      color: $color-grey-5;
+      font-size: 16px;
+      line-height: 22px;
+      margin-top: 14px;
+
+      a {
+        color: $color-black;
+        font-weight: 700;
+        text-decoration: underline;
+        text-decoration-thickness: 2px;
+
+        &:hover {
+          color: $color-red;
+        }
+      }
+    }
   }
 
   &__methodology {


### PR DESCRIPTION
Adds a link from the Agents on Rails benchmark section to the open-source Rails AI evaluation suite, making the underlying evaluations easier to discover.

## Validation

- Verified the link and supporting text on the local `/ai` page with Jekyll.



<img width="2026" height="604" alt="image" src="https://github.com/user-attachments/assets/1f9a0b66-9e0c-4fa0-8126-76da2fac1b50" />

