### PR TITLE
feat: add /.well-known/security.txt (RFC 9116)

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: https://hackerone.com/rails
+Expires: 2027-08-13T00:00:00.000Z
+Policy: https://rubyonrails.org/security
+Preferred-Languages: en

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,9 @@ plugins:
   - jekyll-sitemap
   - jemoji
 
+include:
+  - .well-known
+
 exclude:
   - Gemfile
   - Gemfile.lock


### PR DESCRIPTION
Closes #693

Definitely not high priority, but it was simple enough that I figured I'd just send it along rather than let it sit.

`/.well-known/security.txt` was 404ing while `/security` happily points people at HackerOne. This adds the little RFC 9116 file so scanners and researchers can find the reporting process without guessing.

To answer the "which directory?" question from the issue: Jekyll skips dot-directories, so the file on its own does nothing. `_config.yml` needs the matching `include` before it'll actually land in `_site`. Verified locally that it shows up at `/.well-known/security.txt` and that nothing else snuck into the build.

One thing to keep in mind — `Expires` is a required field and I set it to 2027-08-13, so it'll need a bump before then. Happy to shorten that or trim the `Preferred-Languages` line if you'd rather keep it leaner.

🤖 Co-authored with Claude Code
