### PR TITLE
Fix broken markdown and wrong episode link in the Joanna Wang post

### DIFF
--- a/_posts/2026-08-18-on-rails-joanna-wang-sixfold.markdown
+++ b/_posts/2026-08-18-on-rails-joanna-wang-sixfold.markdown
@@ -11,7 +11,7 @@ published: true
 date: 2026-08-18
 ---
 
-<p><a href="https://www.linkedin.com/in/tianqi-joanna-wang/">Joanna Wang</a> is a senior software engineer at <a href="https://www.sixfold.ai")>Sixfold</a>, where the team builds AI underwriting tools that help insurance companies gather data and assess risk. She came to Ruby on Rails after working across Java, Go, Python, and Node.</p>
+<p><a href="https://www.linkedin.com/in/tianqi-joanna-wang/">Joanna Wang</a> is a senior software engineer at <a href="https://www.sixfold.ai">Sixfold</a>, where the team builds AI underwriting tools that help insurance companies gather data and assess risk. She came to Ruby on Rails after working across Java, Go, Python, and Node.</p>
 <p>Robby and Joanna get into why the homegrown orchestration they built on state machines and callbacks turned brittle, what moving to <a href="https://github.com/hatchet-dev/hatchet">Hatchet</a> changed, and the tradeoffs of leaning on a gem that is no longer maintained. They also talk about what happened when the team went fully agentic, and why Rails magic is easier to understand when an agent can trace it for you.</p>
 
 **Links:**
@@ -19,4 +19,4 @@ date: 2026-08-18
 - [Sixfold](https://www.sixfold.ai)
 - [Hatchet](https://github.com/hatchet-dev/hatchet)
 
-<p><a href="https://podcast.rubyonrails.org/2462975/episodes/19597832-aaron-patterson-ractors-jit-compilers-and-rewriting-how-gems-install">Listen to this episode</a> (43m) or <a href="https://podcast.rubyonrails.org">subscribe to On Rails</a> in your podcast player.</p>
+<p><a href="https://podcast.rubyonrails.org/2462975/episodes/19665210-joanna-wang-code-is-cheap-now-developers-still-valuable">Listen to this episode</a> (43m) or <a href="https://podcast.rubyonrails.org">subscribe to On Rails</a> in your podcast player.</p>


### PR DESCRIPTION
Two small mistakes in commit 99d083c:

- An extra `)` in the Sixfold link. The site could not read the link, so it printed the raw code on the page as plain text.
- The "Listen to this episode" link went to the Aaron Patterson episode. Now it goes to Joanna's.

cc @AmandaPerino