### PR TITLE
Re-enable jekyll-redirect-from to fix trailing slash 404s

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ world25_title: Rails World 2025 - Amsterdam, NL
 plugins:
   - jekyll-feed
   - jekyll-paginate
-  # - jekyll-redirect-from
+  - jekyll-redirect-from
   - jekyll-sitemap
   - jemoji
 


### PR DESCRIPTION
The jekyll-redirect-from plugin was re-enabled in https://github.com/rails/website/pull/563 so that URLs with a trailing slash (e.g. /doctrine/ and /doctrine/ja/) redirect to their canonical counterparts via `redirect_from` front matter. However, https://github.com/rails/website/pull/630 accidentally commented it out again as an unrelated hunk, which made these trailing slash URLs return 404.

Re-enabling the plugin restores the redirect stubs. The redirect loop previously fixed in https://github.com/rails/website/pull/585 does not recur: all files with redirect_from were audited and none has a `redirect_from` path that collides with its own permalink output.